### PR TITLE
feat(entitlements): implement issue #21 paid-tier gating slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The current public build includes:
 - **Wiki** reference content for shipping/API concepts
 - **Directory** curated links to specs, tools, and carrier resources
 - **Anonymous local progress** stored in the browser today
+- **Tier-aware gating** for premium challenge depth while keeping public educational pages crawlable
 
 ## V2 Direction
 
@@ -24,6 +25,23 @@ The active v2 plan is tracked in [`specs/current-changes`](specs/current-changes
 - hosted access tiers: anonymous sample -> signed-in free -> Pro -> Enterprise
 - Creem billing, Resend transactional email, and `shipping.apidojo.app` as the target production domain under the `apidojo.app` umbrella
 - stronger SEO-first knowledge architecture around lessons, wiki, and directory surfaces
+
+## Hosted Access Matrix (Current Slice)
+
+- **Free**
+  - Public lessons, wiki, and directory
+  - Core lesson drills and standard incident-arena scenarios
+  - Signed-in server-backed progress
+- **Pro**
+  - All Free surfaces
+  - Premium lesson and arena challenge rerolls
+  - Advanced review-depth scenario access
+  - Certificate-basic capability reserved for certificate implementation
+- **Enterprise**
+  - All Pro surfaces
+  - Branded certificate capability, team reporting, and custom premium-pack capability
+
+The current implementation gates premium actions and depth (for example rerolls and advanced arena ladders) instead of hiding public SEO-critical pages.
 
 ## Architectural Caveat
 

--- a/specs/current-changes/issue-21-paid-tier-content-gating-plan.md
+++ b/specs/current-changes/issue-21-paid-tier-content-gating-plan.md
@@ -6,6 +6,17 @@ Parent: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
 Branch: `codex/issue-21-paid-tier-gating`
 Scope: Implement the hosted/premium v2 surface that remains after the auth, billing, entitlement, and compliance foundations.
 
+## Execution Progress
+
+- [x] Align scope with `#5`: keep this issue focused on paid tiers and entitlement gating, keep `#15` separate, and keep `#13/#16` out of scope.
+- [x] Define and ship a concrete Free/Pro/Enterprise capability matrix in runtime code and settings UX.
+- [x] Gate premium depth and premium reroll actions through entitlement-aware checks while keeping lesson/wiki/directory pages publicly crawlable.
+- [x] Add locked-content and upgrade UX for premium lesson rerolls and advanced arena scenario depth.
+- [x] Add safe fallback behavior for missing/errored entitlement fetches and verify inactive/canceled subscription downgrades remain free.
+- [x] Add regression tests for access-policy helpers and entitlement downgrade behavior.
+- [x] Run full validation suite and fix any regressions.
+- [x] Update memory-bank release/changelog entries and open PR for review.
+
 ## Goal
 
 Turn the v2 paid-access direction from foundations and outline docs into user-visible, entitlement-aware product behavior.

--- a/specs/current-changes/issue-21-paid-tier-content-gating-plan.md
+++ b/specs/current-changes/issue-21-paid-tier-content-gating-plan.md
@@ -16,6 +16,8 @@ Scope: Implement the hosted/premium v2 surface that remains after the auth, bill
 - [x] Add regression tests for access-policy helpers and entitlement downgrade behavior.
 - [x] Run full validation suite and fix any regressions.
 - [x] Update memory-bank release/changelog entries and open PR for review.
+- [x] Address PR review feedback by routing entitlement fallback failures through a shared observability wrapper instead of route-local console logging.
+- [x] Create v2 follow-up issues for full Sentry integration and dev-only tiered seed users.
 
 ## Goal
 
@@ -54,3 +56,8 @@ Turn the v2 paid-access direction from foundations and outline docs into user-vi
 - `pnpm test`
 - `pnpm test:checkpoint`
 - `pnpm build`
+
+## Follow-Up Issues
+
+- [#26](https://github.com/BallLightningAB/shipping-api-dojo/issues/26): Add Sentry Free-tier observability for hosted v2 errors.
+- [#27](https://github.com/BallLightningAB/shipping-api-dojo/issues/27): Add dev-only tiered seed users and Playwright auth states.

--- a/specs/current-changes/issue-26-sentry-observability-plan.md
+++ b/specs/current-changes/issue-26-sentry-observability-plan.md
@@ -1,0 +1,40 @@
+# Issue 26 Sentry Observability Plan
+
+Issue: [#26](https://github.com/BallLightningAB/shipping-api-dojo/issues/26)
+Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
+Milestone: v2
+Status: planned
+
+## Goal
+
+Add production-grade error reporting for hosted v2 surfaces, starting with Sentry Free tier, so entitlement, auth, billing, webhook, and route-loader failures are visible to maintainers without relying on local console output.
+
+## Scope
+
+- Configure Sentry for the TanStack Start runtime with environment-aware enablement.
+- Capture server-side and client-side exceptions through a small app-level observability wrapper.
+- Route entitlement fallback failures, auth/session failures, billing webhook failures, and lifecycle email failures through the wrapper.
+- Add privacy-safe context tags such as route, operation, tier fallback, and environment.
+- Explicitly avoid sending PII, auth tokens, request headers, full subscription payloads, or email addresses.
+- Document required Sentry environment variables and local/preview behavior.
+- Add regression coverage for wrapper behavior and fallback-safe error capture.
+
+## Out Of Scope
+
+- Session Replay.
+- Performance tracing beyond a conservative disabled or near-zero baseline.
+- User-level analytics.
+- Alert-routing automation beyond Sentry default project notifications.
+- Paid Sentry usage or high-cardinality event enrichment.
+
+## Acceptance Criteria
+
+- Sentry can be enabled by environment variables without breaking local development when unset.
+- Existing entitlement fallback paths use the observability wrapper rather than direct route-level console logging.
+- Server-only and client-safe contexts are separated so sensitive request data is not captured by default.
+- Documentation explains Free-tier limits, privacy posture, and how to verify a test event.
+- The v2 validation workflow passes.
+
+## Notes
+
+This issue follows the PR review feedback on issue #21 that direct `console.error` calls in route loaders are too easy to miss in production. The issue #21 PR should keep only the lightweight wrapper fix; full Sentry integration belongs here.

--- a/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
+++ b/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
@@ -1,0 +1,49 @@
+# Issue 27 Dev Tier Seeded Users Plan
+
+Issue: [#27](https://github.com/BallLightningAB/shipping-api-dojo/issues/27)
+Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
+Milestone: v2
+Status: planned
+
+## Goal
+
+Provide a safe development-only way to test Free, Pro, Enterprise, canceled, and inactive paid states through real auth and billing-shaped entitlement resolution.
+
+## Scope
+
+- Add a development-only seed command for tiered auth users and subscription fixtures.
+- Create deterministic test users for at least Free, Pro, Enterprise, and canceled or inactive subscription states.
+- Seed billing-shaped subscription rows instead of bypassing the resolver with manual entitlements only.
+- Guard the seed command so it cannot run against production or non-local environments accidentally.
+- Document credentials, reset behavior, and expected entitlement outcomes for local development.
+- Add Playwright storage-state or helper setup so browser tests can exercise each tier intentionally.
+- Add regression coverage for resolver behavior across seeded fixture states.
+
+## Proposed Dev Users
+
+| Email | Expected state |
+| --- | --- |
+| `free@dev.shipping-api-dojo.local` | signed-in Free, no active paid subscription |
+| `pro@dev.shipping-api-dojo.local` | signed-in Pro, active paid subscription |
+| `enterprise@dev.shipping-api-dojo.local` | signed-in Enterprise, active enterprise subscription |
+| `canceled@dev.shipping-api-dojo.local` | signed-in user with latest canceled subscription, falls back safely to Free unless manually granted |
+| `inactive@dev.shipping-api-dojo.local` | signed-in user with inactive or past-due billing-shaped state, falls back safely to Free |
+
+## Out Of Scope
+
+- Production test accounts.
+- Real payment-provider checkout setup.
+- Seeding real customer data.
+- Manual enterprise grant administration UI.
+
+## Acceptance Criteria
+
+- Running the seed command locally creates or updates the dev users idempotently.
+- The entitlement resolver sees the seeded states through the same code path used by production.
+- Playwright can authenticate as each seeded tier without duplicating fragile login steps in every test.
+- Free/canceled/inactive users cannot access premium actions or advanced depth; Pro/Enterprise users can.
+- The v2 validation workflow passes.
+
+## Notes
+
+The seed implementation should use Better Auth-supported account creation where practical and direct Drizzle writes only for billing/subscription fixtures. Manual entitlement rows must not accidentally mask canceled or inactive subscription fallback behavior.

--- a/specs/current-changes/issue-28-seed-security-plan.md
+++ b/specs/current-changes/issue-28-seed-security-plan.md
@@ -1,0 +1,44 @@
+# Issue 28 Seed Security Plan
+
+Issue: [#28](https://github.com/BallLightningAB/shipping-api-dojo/issues/28)
+Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
+Milestone: v2
+Status: planned
+Priority: critical
+
+## Goal
+
+Remove URL-visible randomization seeds from production-grade hosted flows so users cannot share exact randomized practice paths or weaken future certificate validity.
+
+## Problem
+
+The current v2 randomization model can expose seeds in route search params such as lesson or arena URLs. That was acceptable for proving deterministic randomization mechanics, but it is not acceptable for certificate-bearing or competitive paid practice flows because copied URLs can reproduce the same randomized path for another user.
+
+## Scope
+
+- Move seed generation for protected practice flows to server-authoritative logic.
+- Store seed ownership server-side, tied to the user/session/progress record that owns the practice attempt.
+- Remove seed values from shareable URLs and client-controlled search params where certificate or premium validity depends on uniqueness.
+- Preserve SEO/public educational crawlability by keeping lesson/wiki/directory content visible while protecting user-specific randomized attempt state.
+- Add tests that verify seeds are not present in URLs, client-extractable route state, or public page markup for protected flows.
+- Document the replay, reset, and share-link rules for anonymous sample, signed-in free, Pro, Enterprise, and future certificate flows.
+
+## Out Of Scope
+
+- Issuing certificates.
+- Building shareable credential pages.
+- Adding new randomization dimensions beyond the existing content-family runtime.
+- Rewriting public lesson content routes as authenticated-only pages.
+
+## Acceptance Criteria
+
+- Seeds are never exposed in URLs for protected randomized practice flows.
+- Seeds are generated server-side.
+- Seeds are stored server-side in session-backed or database-backed state.
+- Seed-to-user mapping is not reusable by another user through a copied URL.
+- Tests verify seed values cannot be extracted from client-side URLs or public markup where protected flow security matters.
+- Existing public educational pages remain crawlable and SSR-visible.
+
+## Implementation Notes
+
+Treat this as a security and product-integrity prerequisite before certificates or any claim of unique randomized challenge validity. The first implementation pass should map every current seed-bearing route/search param, decide which flows remain anonymous/demo-only, and then move signed-in and premium practice attempts behind server-authoritative state.

--- a/specs/current-changes/issue-5-joint-plan.md
+++ b/specs/current-changes/issue-5-joint-plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-04-12
 Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
-Scope: Coordination plan for the full Shipping API Dojo web-v2 program anchored by `#5`, with core execution across `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, and `#27`.
+Scope: Coordination plan for the full Shipping API Dojo web-v2 program anchored by `#5`, with core execution across `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, `#27`, and `#28`.
 
 ## Goal
 
@@ -18,6 +18,7 @@ Deliver issue `#5` through a strict sequence that separates:
 - paid tiers, entitlement-aware content gating, premium access surfaces, and upgrade behavior
 - production-grade hosted error reporting
 - development-only tiered auth and billing-state fixtures for browser validation
+- server-authoritative seed security for certificate-safe randomized practice
 
 Issue `#5` provides the global instructions and guardrails for the whole web-v2 implementation chain. Subplans should not reinterpret its product boundary, testing standard, or SEO posture independently.
 
@@ -40,6 +41,7 @@ Issue `#5` provides the global instructions and guardrails for the whole web-v2 
 - Paid tiers, content gating, upgrade UX, and premium access behavior belong in `#21` because `#10` only documented the future direction and `#11` only shipped foundations.
 - Hosted v2 observability belongs in `#26`; issue `#21` may add a lightweight wrapper but full Sentry setup should stay separate.
 - Dev-only tiered auth and billing-state fixtures belong in `#27` so Free/Pro/Enterprise/canceled states can be exercised without polluting production data.
+- Seed-security hardening belongs in `#28`; deterministic randomization was proven in `#8/#9`, but URL-visible seeds must be removed before certificate-bearing or competitive paid practice flows launch.
 - EDI should be treated as a sibling-product strategy issue in `#16`, not as a third track inside Shipping API Dojo and not as a `#5` blocker.
 
 ## Current Execution Notes
@@ -48,7 +50,7 @@ Issue `#5` provides the global instructions and guardrails for the whole web-v2 
 - Public SEO copy should prefer keyword phrases like `shipping API training`, `carrier APIs`, and `carrier integrations` instead of reviving the old `API Trainer` product label.
 - Issues `#10`, `#12`, `#19`, and `#20` are complete, but `#10` was outline-only and does not mean paid tiers/content gating are implemented.
 - Issue `#5` remains open until `#15` and `#21` complete.
-- Issues `#26` and `#27` are now in-scope v2 support sub-issues under `#5`.
+- Issues `#26`, `#27`, and `#28` are now in-scope v2 support sub-issues under `#5`.
 - Issues `#13` and `#16` are still useful strategy work, but they are not blockers for `#5`.
 - During future implementation issues, keep GitHub, the issue-local plan artifact, and `active-context.yaml` aligned so resumability does not depend on terminal history.
 
@@ -69,6 +71,7 @@ Additional v2 support issues:
 - `#21` is an in-scope v2 sub-issue for paid tiers, entitlement-aware content gating, and premium access surfaces.
 - `#26` is an in-scope v2 sub-issue for Sentry Free-tier observability on hosted error paths.
 - `#27` is an in-scope v2 sub-issue for dev-only tiered seed users and Playwright auth states.
+- `#28` is an in-scope critical v2 sub-issue for server-authoritative seed security before certificates or challenge-validity claims.
 - `#13` is follow-on mobile-readiness/native strategy work outside `#5`.
 - `#16` is follow-on EDI sibling-product strategy work outside `#5`.
 
@@ -86,6 +89,7 @@ Additional v2 support issues:
 - `#21` implements the paid-tier/content-gating and premium access behavior that `#10` outlined and `#11` made possible.
 - `#26` adds Sentry-backed observability so hosted auth, billing, entitlement, webhook, and route-loader failures are visible without relying on console output.
 - `#27` adds development-only seeded users and browser auth states for exercising tiered access through production-like resolver paths.
+- `#28` removes URL-visible seed exposure from protected randomized practice by moving seed ownership into server-authoritative state.
 - `#13` and `#16` are separate strategy follow-ons and do not block `#5`.
 
 ## SEO And Knowledge-Surface Guardrails
@@ -108,12 +112,13 @@ Additional v2 support issues:
 | `I5D4` 20 lessons | `#9` | Editorial lessons remain authored, not AI-generated. |
 | `I5D5` 20 drill families | `#9` | Existing drills are regrouped into the family taxonomy. |
 | `I5D6` 20 scenario families | `#9` | Existing scenarios are absorbed into the family taxonomy. |
-| `I5D7` linked sub-issue execution plan | `#7`, `#11`, `#8`, `#9`, `#15`, `#21`, `#26`, `#27` | Satisfied when the in-scope issue graph and plan set are in place. |
+| `I5D7` linked sub-issue execution plan | `#7`, `#11`, `#8`, `#9`, `#15`, `#21`, `#26`, `#27`, `#28` | Satisfied when the in-scope issue graph and plan set are in place. |
 | `I5D8` separate higher-value randomization track | `#10` | Outline only in this phase. |
 | `I5D9` paid tiers, content gating, and premium access surfaces | `#21` | Implementation work remains open. |
 | `I5D10` deep wiki and directory reference expansion | `#15` | In-scope v2 knowledge-surface expansion remains open. |
 | `I5D11` hosted error observability | `#26` | Add Sentry Free-tier reporting with privacy-safe context. |
 | `I5D12` tiered dev auth fixtures | `#27` | Add seeded Free/Pro/Enterprise/canceled states and Playwright auth helpers. |
+| `I5D13` server-authoritative seed security | `#28` | Remove URL-visible seeds from protected randomized practice flows before certificate launch. |
 
 ## Rough Estimates
 
@@ -129,8 +134,9 @@ Additional v2 support issues:
 | `#21` | paid tiers, entitlement gating, and premium access surfaces | 18h | 10h |
 | `#26` | Sentry Free-tier observability | 4h | 2h |
 | `#27` | dev-only tiered seed users and Playwright auth states | 6h | 4h |
+| `#28` | seed-security hardening | 8h | 5h |
 | Core chain total | `#5` umbrella rollup (`#7/#11/#8/#9/#10`) | 100h | 52h |
-| Full `#5` web-v2 total | core chain plus `#12/#15/#21/#26/#27` | 150h | 78h |
+| Full `#5` web-v2 total | core chain plus `#12/#15/#21/#26/#27/#28` | 158h | 83h |
 | Separate strategy follow-ons | `#13` mobile-readiness and `#16` EDI sibling-product strategy | 14h | 6h |
 
 ## Dependencies
@@ -167,6 +173,7 @@ Additional v2 support issues:
 | Paid tiers remain foundation-only | v2 launch lacks upgrade behavior and content gating | Complete `#21` before treating `#5` as done. |
 | Hosted failures remain console-only | production entitlement or billing failures are missed | Complete `#26` before enabling paid hosted rollout. |
 | Paid-tier QA depends on ad hoc accounts | regressions slip across Free/Pro/Enterprise/canceled states | Complete `#27` before relying on browser validation for paid access. |
+| URL-visible seeds remain in protected flows | copied URLs can reproduce randomized attempts and undermine future certificate validity | Complete `#28` before certificates or challenge-validity claims launch. |
 
 ## Shared Product Boundaries
 
@@ -215,7 +222,7 @@ Every implementation issue in this chain must include iterative validation, not 
 This planning package is complete when:
 
 - the v2 issue plans and follow-on outline artifacts exist in `specs/current-changes`
-- GitHub issues `#5`, `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, and `#27` match this structure
+- GitHub issues `#5`, `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, `#27`, and `#28` match this structure
 - `#13` and `#16` are explicitly marked as separate strategy follow-ons outside `#5`
 - the memory-bank reflects the new order and scope
 - the repo is ready to execute work in branch order without inventing architecture mid-stream

--- a/specs/current-changes/issue-5-joint-plan.md
+++ b/specs/current-changes/issue-5-joint-plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-04-12
 Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
-Scope: Coordination plan for the full Shipping API Dojo web-v2 program anchored by `#5`, with core execution across `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, and `#21`.
+Scope: Coordination plan for the full Shipping API Dojo web-v2 program anchored by `#5`, with core execution across `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, and `#27`.
 
 ## Goal
 
@@ -16,6 +16,8 @@ Deliver issue `#5` through a strict sequence that separates:
 - launch-readiness privacy/compliance work
 - deeper wiki expansion beyond the core curriculum
 - paid tiers, entitlement-aware content gating, premium access surfaces, and upgrade behavior
+- production-grade hosted error reporting
+- development-only tiered auth and billing-state fixtures for browser validation
 
 Issue `#5` provides the global instructions and guardrails for the whole web-v2 implementation chain. Subplans should not reinterpret its product boundary, testing standard, or SEO posture independently.
 
@@ -36,6 +38,8 @@ Issue `#5` provides the global instructions and guardrails for the whole web-v2 
 - Every implementation issue must add or update automated tests wherever the behavior can be covered mechanically, then use browser-control validation for route and auth flows that still require end-to-end confirmation.
 - Broad carrier-reference expansion belongs in `#15`, not `#9`, and remains inside the `#5` v2 umbrella.
 - Paid tiers, content gating, upgrade UX, and premium access behavior belong in `#21` because `#10` only documented the future direction and `#11` only shipped foundations.
+- Hosted v2 observability belongs in `#26`; issue `#21` may add a lightweight wrapper but full Sentry setup should stay separate.
+- Dev-only tiered auth and billing-state fixtures belong in `#27` so Free/Pro/Enterprise/canceled states can be exercised without polluting production data.
 - EDI should be treated as a sibling-product strategy issue in `#16`, not as a third track inside Shipping API Dojo and not as a `#5` blocker.
 
 ## Current Execution Notes
@@ -44,6 +48,7 @@ Issue `#5` provides the global instructions and guardrails for the whole web-v2 
 - Public SEO copy should prefer keyword phrases like `shipping API training`, `carrier APIs`, and `carrier integrations` instead of reviving the old `API Trainer` product label.
 - Issues `#10`, `#12`, `#19`, and `#20` are complete, but `#10` was outline-only and does not mean paid tiers/content gating are implemented.
 - Issue `#5` remains open until `#15` and `#21` complete.
+- Issues `#26` and `#27` are now in-scope v2 support sub-issues under `#5`.
 - Issues `#13` and `#16` are still useful strategy work, but they are not blockers for `#5`.
 - During future implementation issues, keep GitHub, the issue-local plan artifact, and `active-context.yaml` aligned so resumability does not depend on terminal history.
 
@@ -62,6 +67,8 @@ Additional v2 support issues:
 - `#12` must complete before production auth and paid features are enabled.
 - `#15` is an in-scope v2 sub-issue for the deep wiki and directory expansion after issue `#9` completes the curriculum-linked wiki surface.
 - `#21` is an in-scope v2 sub-issue for paid tiers, entitlement-aware content gating, and premium access surfaces.
+- `#26` is an in-scope v2 sub-issue for Sentry Free-tier observability on hosted error paths.
+- `#27` is an in-scope v2 sub-issue for dev-only tiered seed users and Playwright auth states.
 - `#13` is follow-on mobile-readiness/native strategy work outside `#5`.
 - `#16` is follow-on EDI sibling-product strategy work outside `#5`.
 
@@ -77,6 +84,8 @@ Additional v2 support issues:
 - `#12` covers EU privacy/storage/launch compliance before hosted auth and paid rollout.
 - `#15` expands the wiki beyond curriculum-linked support pages into a vendor/business-unit/region/protocol library.
 - `#21` implements the paid-tier/content-gating and premium access behavior that `#10` outlined and `#11` made possible.
+- `#26` adds Sentry-backed observability so hosted auth, billing, entitlement, webhook, and route-loader failures are visible without relying on console output.
+- `#27` adds development-only seeded users and browser auth states for exercising tiered access through production-like resolver paths.
 - `#13` and `#16` are separate strategy follow-ons and do not block `#5`.
 
 ## SEO And Knowledge-Surface Guardrails
@@ -99,10 +108,12 @@ Additional v2 support issues:
 | `I5D4` 20 lessons | `#9` | Editorial lessons remain authored, not AI-generated. |
 | `I5D5` 20 drill families | `#9` | Existing drills are regrouped into the family taxonomy. |
 | `I5D6` 20 scenario families | `#9` | Existing scenarios are absorbed into the family taxonomy. |
-| `I5D7` linked sub-issue execution plan | `#7`, `#11`, `#8`, `#9`, `#15`, `#21` | Satisfied when the in-scope issue graph and plan set are in place. |
+| `I5D7` linked sub-issue execution plan | `#7`, `#11`, `#8`, `#9`, `#15`, `#21`, `#26`, `#27` | Satisfied when the in-scope issue graph and plan set are in place. |
 | `I5D8` separate higher-value randomization track | `#10` | Outline only in this phase. |
 | `I5D9` paid tiers, content gating, and premium access surfaces | `#21` | Implementation work remains open. |
 | `I5D10` deep wiki and directory reference expansion | `#15` | In-scope v2 knowledge-surface expansion remains open. |
+| `I5D11` hosted error observability | `#26` | Add Sentry Free-tier reporting with privacy-safe context. |
+| `I5D12` tiered dev auth fixtures | `#27` | Add seeded Free/Pro/Enterprise/canceled states and Playwright auth helpers. |
 
 ## Rough Estimates
 
@@ -116,8 +127,10 @@ Additional v2 support issues:
 | `#12` | EU privacy/storage/launch compliance | 8h | 4h |
 | `#15` | deep wiki expansion | 14h | 6h |
 | `#21` | paid tiers, entitlement gating, and premium access surfaces | 18h | 10h |
+| `#26` | Sentry Free-tier observability | 4h | 2h |
+| `#27` | dev-only tiered seed users and Playwright auth states | 6h | 4h |
 | Core chain total | `#5` umbrella rollup (`#7/#11/#8/#9/#10`) | 100h | 52h |
-| Full `#5` web-v2 total | core chain plus `#12/#15/#21` | 140h | 72h |
+| Full `#5` web-v2 total | core chain plus `#12/#15/#21/#26/#27` | 150h | 78h |
 | Separate strategy follow-ons | `#13` mobile-readiness and `#16` EDI sibling-product strategy | 14h | 6h |
 
 ## Dependencies
@@ -152,6 +165,8 @@ Additional v2 support issues:
 | Scenario authoring scope grows faster than expected | `#9` expands materially | Deliver in waves and validate each wave before opening the next. |
 | Carrier wiki scope expands inside `#9` | `#9` loses focus | Defer the broader taxonomy and reference-library work to `#15`. |
 | Paid tiers remain foundation-only | v2 launch lacks upgrade behavior and content gating | Complete `#21` before treating `#5` as done. |
+| Hosted failures remain console-only | production entitlement or billing failures are missed | Complete `#26` before enabling paid hosted rollout. |
+| Paid-tier QA depends on ad hoc accounts | regressions slip across Free/Pro/Enterprise/canceled states | Complete `#27` before relying on browser validation for paid access. |
 
 ## Shared Product Boundaries
 
@@ -200,7 +215,7 @@ Every implementation issue in this chain must include iterative validation, not 
 This planning package is complete when:
 
 - the v2 issue plans and follow-on outline artifacts exist in `specs/current-changes`
-- GitHub issues `#5`, `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, and `#21` match this structure
+- GitHub issues `#5`, `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, and `#27` match this structure
 - `#13` and `#16` are explicitly marked as separate strategy follow-ons outside `#5`
 - the memory-bank reflects the new order and scope
 - the repo is ready to execute work in branch order without inventing architecture mid-stream

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,4 +1,31 @@
 entries:
+  - date: "2026-04-21"
+    version: "1.1.18"
+    commit: TBD
+    status: in-progress
+    title: "feat(entitlements): ship issue #21 paid-tier gating slice"
+    details: |-
+      Started issue #21 with a concrete paid-tier implementation slice focused
+      on entitlement-aware access behavior and upgrade UX while keeping SEO
+      surfaces crawlable.
+
+      - Added a concrete Free/Pro/Enterprise capability matrix and centralized
+        access-policy helpers for premium lesson rerolls and advanced arena
+        scenario depth
+      - Wired lesson and arena route checks to entitlement capabilities with a
+        safe fallback to free access when paid state is missing or unavailable
+      - Added locked-content and upgrade UX for premium challenge actions
+        without hiding public lesson/wiki/directory pages
+      - Added a paid-access matrix surface in settings, including visibility of
+        current entitlement state and inactive/canceled subscription fallback
+        messaging
+      - Added regression coverage for the access-policy rules, canceled-subscription
+        downgrade behavior, runtime ladder metadata, and updated browser smoke
+        assertions for the new lock/upgrade flows
+      - Updated issue-21 current-changes and README paid-tier documentation to
+        match implemented behavior
+    refs:
+      - "I21D1, I21D2, I21D3, I21D4, I21D5, I21D6"
   - date: "2026-04-20"
     version: "1.1.17"
     commit: TBD

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,8 +1,27 @@
 entries:
   - date: "2026-04-21"
-    version: "1.1.19"
+    version: "1.1.20"
     commit: TBD
     status: in-progress
+    title: "docs(planning): track issue #28 seed security"
+    details: |-
+      Added issue #28 to the local v2 planning and memory-bank state as a
+      critical seed-security blocker for certificate-safe randomized practice.
+
+      - Added a current-changes artifact for server-authoritative seed
+        ownership and URL seed removal
+      - Updated the issue #5 joint plan to include #28 in scope, risks,
+        estimates, and deliverable mapping
+      - Updated active-context so #28 is tracked under the #5 roadmap with
+        critical priority and an explicit remaining deliverable
+      - Prepared PR #25 for merge after resolving the observability review
+        comment
+    refs:
+      - "I5D7, I5D13"
+  - date: "2026-04-21"
+    version: "1.1.19"
+    commit: 40d0f63
+    status: completed
     title: "chore(observability): address paid-tier review feedback"
     details: |-
       Addressed PR review feedback on the issue #21 paid-tier gating branch

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,8 +1,30 @@
 entries:
   - date: "2026-04-21"
-    version: "1.1.18"
+    version: "1.1.19"
     commit: TBD
     status: in-progress
+    title: "chore(observability): address paid-tier review feedback"
+    details: |-
+      Addressed PR review feedback on the issue #21 paid-tier gating branch
+      and split follow-up operational work into explicit v2 sub-issues.
+
+      - Added a shared observability logger for exception capture with
+        privacy-safe route and operation context
+      - Replaced route-local entitlement fallback console logging in lesson
+        and arena loaders with the shared logger
+      - Added unit coverage for logger normalization and context handling
+      - Created issue #26 for Sentry Free-tier hosted error observability
+        under parent issue #5 and milestone v2
+      - Created issue #27 for dev-only tiered seed users plus Playwright auth
+        states under parent issue #5 and milestone v2
+      - Updated issue #5 and issue #21 current-changes artifacts plus
+        memory-bank roadmap state to include the new v2 sub-issues
+    refs:
+      - "I5D7, I5D11, I5D12, I21D4, I21D5"
+  - date: "2026-04-21"
+    version: "1.1.18"
+    commit: 230a792
+    status: completed
     title: "feat(entitlements): ship issue #21 paid-tier gating slice"
     details: |-
       Started issue #21 with a concrete paid-tier implementation slice focused

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.1.19"
+  release: "1.1.20"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -30,9 +30,10 @@ roadmap:
         - "[I5D10] Expand the wiki and directory beyond curriculum support into the v2 carrier reference surface"
         - "[I5D11] Add privacy-safe Sentry Free-tier observability for hosted v2 error paths"
         - "[I5D12] Add dev-only tiered auth users, billing-shaped seed state, and Playwright auth helpers"
+        - "[I5D13] Remove URL-visible seeds from protected randomized practice flows before certificate launch"
       est:
-        dev_h: 150
-        test_h: 78
+        dev_h: 158
+        test_h: 83
       sub_issues:
         - id: content-expansion-scoping
           issue: "#7"
@@ -115,11 +116,19 @@ roadmap:
           status: planned
           links:
             issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/27"
+        - id: seed-security
+          issue: "#28"
+          title: "Security: Seed exposure in URLs undermines randomized practice and certificate validity"
+          status: planned
+          priority: critical
+          links:
+            issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/28"
       remaining_deliverables:
         - "[I5D9] Implement entitlement-aware paid tiers, content gating, premium access surfaces, and launch-ready upgrade behavior"
         - "[I5D10] Expand the wiki and directory beyond curriculum support into the v2 carrier reference surface"
         - "[I5D11] Add privacy-safe Sentry Free-tier observability for hosted v2 error paths"
         - "[I5D12] Add dev-only tiered auth users, billing-shaped seed state, and Playwright auth helpers"
+        - "[I5D13] Remove URL-visible seeds from protected randomized practice flows before certificate launch"
       progress_log:
         - note: "Research captured in specs/current-changes/issue-5-content-expansion-research.md and GitHub issue #5 was updated to target minimum viable randomization, 20 lessons, 20 drill families, and 20 scenario families."
         - note: "Created the issue-5 joint plan plus issue-specific plan artifacts for #7, #11, #8, #9, and #10; added GitHub issue #11 for auth/billing/email/domain foundation; and updated the roadmap to sequence work as #7 -> #11 -> #8 -> #9 with #10 as follow-on."
@@ -143,6 +152,7 @@ roadmap:
         - note: "Corrected issue #5 back to an open v2 umbrella: #10 remains outline-only, #12 remains compliance-only, #15 is now an in-scope v2 sub-issue, #21 tracks the missing paid-tier/content-gating implementation, and #13/#16 remain separate strategy follow-ons outside #5 closure criteria."
         - note: "Started issue #21 on codex/issue-21-paid-tier-gating: shipped the first paid-tier slice with a concrete Free/Pro/Enterprise matrix, entitlement-aware gating for premium lesson rerolls plus advanced arena depth, locked/upgrade UX that keeps public educational pages crawlable, safe free fallback behavior for missing/inactive/canceled paid states, and regression coverage for the new access-policy logic."
         - note: "Addressed PR #25 observability feedback by centralizing entitlement fallback exception capture in a shared logger, and created #26 plus #27 as v2 sub-issues under #5 for full Sentry integration and dev-only tiered seed users."
+        - note: "Added issue #28 to the v2 #5 planning graph as a critical seed-security sub-issue so URL-visible randomized seeds are removed before certificate-bearing or challenge-validity claims launch."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.1.18"
+  release: "1.1.19"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -28,9 +28,11 @@ roadmap:
         - "[I5D8] Keep higher-value randomization, certificates, and premium challenge direction as separate follow-on work"
         - "[I5D9] Implement entitlement-aware paid tiers, content gating, premium access surfaces, and launch-ready upgrade behavior"
         - "[I5D10] Expand the wiki and directory beyond curriculum support into the v2 carrier reference surface"
+        - "[I5D11] Add privacy-safe Sentry Free-tier observability for hosted v2 error paths"
+        - "[I5D12] Add dev-only tiered auth users, billing-shaped seed state, and Playwright auth helpers"
       est:
-        dev_h: 140
-        test_h: 72
+        dev_h: 150
+        test_h: 78
       sub_issues:
         - id: content-expansion-scoping
           issue: "#7"
@@ -101,9 +103,23 @@ roadmap:
           status: in-progress
           links:
             issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/21"
+        - id: sentry-observability
+          issue: "#26"
+          title: "Add Sentry Free-tier observability for hosted v2 errors"
+          status: planned
+          links:
+            issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/26"
+        - id: dev-tier-seeded-users
+          issue: "#27"
+          title: "Add dev-only tiered seed users and Playwright auth states"
+          status: planned
+          links:
+            issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/27"
       remaining_deliverables:
         - "[I5D9] Implement entitlement-aware paid tiers, content gating, premium access surfaces, and launch-ready upgrade behavior"
         - "[I5D10] Expand the wiki and directory beyond curriculum support into the v2 carrier reference surface"
+        - "[I5D11] Add privacy-safe Sentry Free-tier observability for hosted v2 error paths"
+        - "[I5D12] Add dev-only tiered auth users, billing-shaped seed state, and Playwright auth helpers"
       progress_log:
         - note: "Research captured in specs/current-changes/issue-5-content-expansion-research.md and GitHub issue #5 was updated to target minimum viable randomization, 20 lessons, 20 drill families, and 20 scenario families."
         - note: "Created the issue-5 joint plan plus issue-specific plan artifacts for #7, #11, #8, #9, and #10; added GitHub issue #11 for auth/billing/email/domain foundation; and updated the roadmap to sequence work as #7 -> #11 -> #8 -> #9 with #10 as follow-on."
@@ -126,6 +142,7 @@ roadmap:
         - note: "Completed issue #20: expanded the six remaining two-variant drill families to four authored variants each, added runtime regression coverage for the watch-list family pool size and missing-drill references, updated the audit matrix so the former 12-outcome lessons now report 24 outcomes across 400 seeds, and archived the completed challenge-depth artifacts."
         - note: "Corrected issue #5 back to an open v2 umbrella: #10 remains outline-only, #12 remains compliance-only, #15 is now an in-scope v2 sub-issue, #21 tracks the missing paid-tier/content-gating implementation, and #13/#16 remain separate strategy follow-ons outside #5 closure criteria."
         - note: "Started issue #21 on codex/issue-21-paid-tier-gating: shipped the first paid-tier slice with a concrete Free/Pro/Enterprise matrix, entitlement-aware gating for premium lesson rerolls plus advanced arena depth, locked/upgrade UX that keeps public educational pages crawlable, safe free fallback behavior for missing/inactive/canceled paid states, and regression coverage for the new access-policy logic."
+        - note: "Addressed PR #25 observability feedback by centralizing entitlement fallback exception capture in a shared logger, and created #26 plus #27 as v2 sub-issues under #5 for full Sentry integration and dev-only tiered seed users."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.1.17"
+  release: "1.1.18"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -98,7 +98,7 @@ roadmap:
         - id: paid-tier-content-gating
           issue: "#21"
           title: "Implement paid tiers, entitlement gating, and premium access surfaces"
-          status: planned
+          status: in-progress
           links:
             issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/21"
       remaining_deliverables:
@@ -125,6 +125,7 @@ roadmap:
         - note: "Created issue #20 as the follow-up for expanding the remaining two-variant drill families without changing family IDs, lesson slugs, progress keys, or route contracts."
         - note: "Completed issue #20: expanded the six remaining two-variant drill families to four authored variants each, added runtime regression coverage for the watch-list family pool size and missing-drill references, updated the audit matrix so the former 12-outcome lessons now report 24 outcomes across 400 seeds, and archived the completed challenge-depth artifacts."
         - note: "Corrected issue #5 back to an open v2 umbrella: #10 remains outline-only, #12 remains compliance-only, #15 is now an in-scope v2 sub-issue, #21 tracks the missing paid-tier/content-gating implementation, and #13/#16 remain separate strategy follow-ons outside #5 closure criteria."
+        - note: "Started issue #21 on codex/issue-21-paid-tier-gating: shipped the first paid-tier slice with a concrete Free/Pro/Enterprise matrix, entitlement-aware gating for premium lesson rerolls plus advanced arena depth, locked/upgrade UX that keeps public educational pages crawlable, safe free fallback behavior for missing/inactive/canceled paid states, and regression coverage for the new access-policy logic."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/src/content/runtime.test.ts
+++ b/src/content/runtime.test.ts
@@ -251,5 +251,6 @@ describe("content runtime", () => {
 		expect(ids).not.toContain("soap-fault-detail");
 		expect(ids).not.toContain("wsdl-change-breaks");
 		expect(cards.every((scenario) => Boolean(scenario.progressKey))).toBe(true);
+		expect(cards.every((scenario) => Boolean(scenario.ladderLevel))).toBe(true);
 	});
 });

--- a/src/content/runtime.ts
+++ b/src/content/runtime.ts
@@ -145,6 +145,7 @@ export function getScenarioProgressKey(scenario: Scenario): string {
 export function getArenaScenarioCards(seed: number): Scenario[] {
 	const canonicalCards = scenarioFamilies.map((family) => ({
 		id: family.id,
+		ladderLevel: family.ladderLevel,
 		progressKey: family.id,
 		scenarioFamilyId: family.id,
 		title: family.title,
@@ -164,7 +165,14 @@ export function getScenarioRuntimeById(
 	runSeed: number
 ): Scenario | null {
 	const family = getScenarioFamilyById(id);
-	return family ? family.buildRun(runSeed).scenario : null;
+	if (!family) {
+		return null;
+	}
+
+	return {
+		...family.buildRun(runSeed).scenario,
+		ladderLevel: family.ladderLevel,
+	};
 }
 
 export function getLessonCatalog(): Lesson[] {

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -103,6 +103,7 @@ export interface Scenario {
 	difficulty: "beginner" | "intermediate" | "advanced";
 	evidence?: string[];
 	id: string;
+	ladderLevel?: 1 | 2 | 3 | 4;
 	progressKey?: string;
 	runSeed?: number;
 	scenarioFamilyId?: string;

--- a/src/lib/entitlements/access-policy.test.ts
+++ b/src/lib/entitlements/access-policy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { CAPABILITY_BUNDLES } from "./entitlements";
+import {
+	canAccessScenarioRun,
+	canUseLessonChallengeReroll,
+	canUseScenarioReroll,
+	fallbackFreeEntitlements,
+	requiresPremiumScenarioDepth,
+	TIER_CAPABILITY_MATRIX,
+} from "./access-policy";
+
+describe("entitlement access policy", () => {
+	it("publishes a concrete free/pro/enterprise matrix", () => {
+		expect(TIER_CAPABILITY_MATRIX.map((row) => row.tier)).toEqual([
+			"free",
+			"pro",
+			"enterprise",
+		]);
+		expect(TIER_CAPABILITY_MATRIX.every((row) => row.surfaces.length > 0)).toBe(
+			true
+		);
+	});
+
+	it("falls back to free entitlements when paid state is missing", () => {
+		expect(fallbackFreeEntitlements()).toEqual({
+			capabilities: CAPABILITY_BUNDLES.free,
+			source: "fallback_free",
+			tier: "free",
+		});
+	});
+
+	it("gates lesson and arena rerolls behind premium randomization capability", () => {
+		expect(canUseLessonChallengeReroll(CAPABILITY_BUNDLES.free)).toBe(false);
+		expect(canUseScenarioReroll(CAPABILITY_BUNDLES.free)).toBe(false);
+
+		expect(canUseLessonChallengeReroll(CAPABILITY_BUNDLES.pro)).toBe(true);
+		expect(canUseScenarioReroll(CAPABILITY_BUNDLES.enterprise)).toBe(true);
+	});
+
+	it("keeps baseline scenario runs available while gating advanced depth", () => {
+		expect(requiresPremiumScenarioDepth(1)).toBe(false);
+		expect(requiresPremiumScenarioDepth(2)).toBe(false);
+		expect(requiresPremiumScenarioDepth(3)).toBe(true);
+		expect(requiresPremiumScenarioDepth(4)).toBe(true);
+
+		expect(canAccessScenarioRun(CAPABILITY_BUNDLES.free, 2)).toBe(true);
+		expect(canAccessScenarioRun(CAPABILITY_BUNDLES.free, 3)).toBe(false);
+		expect(canAccessScenarioRun(CAPABILITY_BUNDLES.pro, 3)).toBe(true);
+		expect(canAccessScenarioRun(CAPABILITY_BUNDLES.enterprise, 4)).toBe(true);
+	});
+});

--- a/src/lib/entitlements/access-policy.ts
+++ b/src/lib/entitlements/access-policy.ts
@@ -1,0 +1,81 @@
+import {
+	CAPABILITY_BUNDLES,
+	hasCapability,
+	type EntitlementTier,
+	type ResolvedEntitlements,
+} from "./entitlements";
+
+export const PREMIUM_SCENARIO_MIN_LADDER_LEVEL = 3;
+
+export interface TierCapabilityRow {
+	tier: EntitlementTier;
+	label: string;
+	surfaces: string[];
+}
+
+export const TIER_CAPABILITY_MATRIX: TierCapabilityRow[] = [
+	{
+		tier: "free",
+		label: "Free",
+		surfaces: [
+			"Public lessons, wiki, and directory",
+			"Core lesson drills and standard arena scenarios",
+			"Signed-in server-backed progress",
+		],
+	},
+	{
+		tier: "pro",
+		label: "Pro",
+		surfaces: [
+			"All Free surfaces",
+			"Premium challenge rerolls and variant depth",
+			"Advanced review-mode scenario access",
+			"Basic certificates (when shipped)",
+		],
+	},
+	{
+		tier: "enterprise",
+		label: "Enterprise",
+		surfaces: [
+			"All Pro surfaces",
+			"Branded certificates (when shipped)",
+			"Team reporting and custom premium packs",
+		],
+	},
+];
+
+export function fallbackFreeEntitlements(): ResolvedEntitlements {
+	return {
+		capabilities: CAPABILITY_BUNDLES.free,
+		source: "fallback_free",
+		tier: "free",
+	};
+}
+
+export function canUseLessonChallengeReroll(
+	capabilities: readonly string[]
+): boolean {
+	return hasCapability(capabilities, "randomization.premium.full");
+}
+
+export function canUseScenarioReroll(capabilities: readonly string[]): boolean {
+	return hasCapability(capabilities, "randomization.premium.full");
+}
+
+export function requiresPremiumScenarioDepth(ladderLevel?: number): boolean {
+	return (
+		typeof ladderLevel === "number" &&
+		ladderLevel >= PREMIUM_SCENARIO_MIN_LADDER_LEVEL
+	);
+}
+
+export function canAccessScenarioRun(
+	capabilities: readonly string[],
+	ladderLevel?: number
+): boolean {
+	if (!requiresPremiumScenarioDepth(ladderLevel)) {
+		return true;
+	}
+
+	return hasCapability(capabilities, "review.mode.full");
+}

--- a/src/lib/entitlements/entitlements.test.ts
+++ b/src/lib/entitlements/entitlements.test.ts
@@ -27,6 +27,19 @@ describe("resolveEntitlements", () => {
 		);
 	});
 
+	it("downgrades canceled paid subscriptions to free access", () => {
+		const resolved = resolveEntitlements({
+			subscriptionPlanKey: "pro_monthly",
+			subscriptionStatus: "canceled",
+		});
+
+		expect(resolved.tier).toBe("free");
+		expect(resolved.source).toBe("fallback_free");
+		expect(hasCapability(resolved.capabilities, "content.premium.read")).toBe(
+			false
+		);
+	});
+
 	it("keeps highest tier when both manual and subscription are present", () => {
 		const resolved = resolveEntitlements({
 			manualTier: "enterprise",

--- a/src/lib/observability/logger.test.ts
+++ b/src/lib/observability/logger.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { captureException } from "./logger";
+
+describe("captureException", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("centralizes exception reporting with safe route context", () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			// Suppress expected logger output in this unit test.
+		});
+
+		captureException(new Error("entitlement lookup failed"), {
+			fallbackTier: "free",
+			operation: "resolve_entitlements",
+			route: "/arena",
+		});
+
+		expect(consoleSpy).toHaveBeenCalledWith("[observability] exception", {
+			context: {
+				fallbackTier: "free",
+				operation: "resolve_entitlements",
+				route: "/arena",
+			},
+			error: {
+				message: "entitlement lookup failed",
+				name: "Error",
+			},
+		});
+	});
+
+	it("normalizes non-error throws", () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			// Suppress expected logger output in this unit test.
+		});
+
+		captureException("string failure", {
+			route: "/lesson/$slug",
+			unused: undefined,
+		});
+
+		expect(consoleSpy).toHaveBeenCalledWith("[observability] exception", {
+			context: {
+				route: "/lesson/$slug",
+			},
+			error: {
+				message: "string failure",
+				name: "Error",
+			},
+		});
+	});
+});

--- a/src/lib/observability/logger.ts
+++ b/src/lib/observability/logger.ts
@@ -1,0 +1,28 @@
+export type ObservabilityContext = Record<
+	string,
+	boolean | number | string | null | undefined
+>;
+
+export function captureException(
+	error: unknown,
+	context: ObservabilityContext = {}
+) {
+	const normalizedError =
+		error instanceof Error
+			? error
+			: new Error(String(error ?? "Unknown error"));
+
+	console.error("[observability] exception", {
+		context: removeUndefinedValues(context),
+		error: {
+			message: normalizedError.message,
+			name: normalizedError.name,
+		},
+	});
+}
+
+function removeUndefinedValues(context: ObservabilityContext) {
+	return Object.fromEntries(
+		Object.entries(context).filter(([, value]) => value !== undefined)
+	);
+}

--- a/src/routes/arena/index.tsx
+++ b/src/routes/arena/index.tsx
@@ -13,6 +13,7 @@ import {
 	requiresPremiumScenarioDepth,
 } from "@/lib/entitlements/access-policy";
 import { getCurrentEntitlements } from "@/lib/entitlements/entitlements.sync";
+import { captureException } from "@/lib/observability/logger";
 import { completeScenario } from "@/lib/progress/progress.actions";
 import { progressStore } from "@/lib/progress/progress.store";
 import { makeClientSeed } from "@/lib/randomization";
@@ -42,7 +43,11 @@ export const Route = createFileRoute("/arena/")({
 			const entitlements = await getCurrentEntitlements();
 			capabilities = entitlements.capabilities;
 		} catch (error) {
-			console.error("Failed to resolve arena entitlements", error);
+			captureException(error, {
+				fallbackTier: "free",
+				operation: "resolve_entitlements",
+				route: "/arena",
+			});
 		}
 
 		return {

--- a/src/routes/arena/index.tsx
+++ b/src/routes/arena/index.tsx
@@ -6,6 +6,13 @@ import {
 	getScenarioProgressKey,
 	getScenarioRuntimeById,
 } from "@/content/runtime";
+import {
+	canAccessScenarioRun,
+	canUseScenarioReroll,
+	fallbackFreeEntitlements,
+	requiresPremiumScenarioDepth,
+} from "@/lib/entitlements/access-policy";
+import { getCurrentEntitlements } from "@/lib/entitlements/entitlements.sync";
 import { completeScenario } from "@/lib/progress/progress.actions";
 import { progressStore } from "@/lib/progress/progress.store";
 import { makeClientSeed } from "@/lib/randomization";
@@ -16,7 +23,7 @@ import {
 	useNavigate,
 } from "@tanstack/react-router";
 import { useStore } from "@tanstack/react-store";
-import { CheckCircle, Circle } from "lucide-react";
+import { CheckCircle, Circle, Lock } from "lucide-react";
 import { z } from "zod";
 
 export const Route = createFileRoute("/arena/")({
@@ -28,11 +35,23 @@ export const Route = createFileRoute("/arena/")({
 	loaderDeps: ({ search }) => ({
 		seed: search.seed,
 	}),
-	loader: ({ deps }) => {
+	loader: async ({ deps }) => {
 		const seed = getRouteSeed("arena:index", deps.seed);
+		let capabilities = fallbackFreeEntitlements().capabilities;
+		try {
+			const entitlements = await getCurrentEntitlements();
+			capabilities = entitlements.capabilities;
+		} catch (error) {
+			console.error("Failed to resolve arena entitlements", error);
+		}
 
 		return {
-			cards: getArenaScenarioCards(seed),
+			cards: getArenaScenarioCards(seed).map((card) => ({
+				...card,
+				isLocked: !canAccessScenarioRun(capabilities, card.ladderLevel),
+				requiresPremiumDepth: requiresPremiumScenarioDepth(card.ladderLevel),
+			})),
+			canRerollScenarioRuns: canUseScenarioReroll(capabilities),
 			seed,
 		};
 	},
@@ -61,10 +80,14 @@ export const Route = createFileRoute("/arena/")({
 
 function ArenaPage() {
 	const navigate = useNavigate({ from: "/arena/" });
-	const { cards } = Route.useLoaderData();
+	const { canRerollScenarioRuns, cards } = Route.useLoaderData();
 	const search = Route.useSearch();
+	const activeCard = search.scenario
+		? cards.find((card) => card.id === search.scenario)
+		: null;
+	const activeScenarioLocked = Boolean(activeCard?.isLocked);
 	const activeScenario =
-		search.scenario && search.runSeed
+		search.scenario && search.runSeed && !activeScenarioLocked
 			? getScenarioRuntimeById(search.scenario, search.runSeed)
 			: null;
 
@@ -100,7 +123,7 @@ function ArenaPage() {
 	}
 
 	function handleRerollScenario() {
-		if (!search.scenario) {
+		if (!(search.scenario && canRerollScenarioRuns)) {
 			return;
 		}
 
@@ -112,25 +135,21 @@ function ArenaPage() {
 		});
 	}
 
-	return (
-		<div className="container mx-auto max-w-4xl px-4 py-16">
-			<h1 className="mb-4">Incident Arena</h1>
-			<p className="mb-10 max-w-2xl text-lg text-muted-foreground">
-				Realistic carrier integration incidents. Make decisions, get feedback,
-				and build troubleshooting instincts.
-			</p>
+	let arenaContent: React.ReactNode;
 
-			{activeScenario ? (
-				<div>
-					<button
-						className="mb-6 text-sm text-muted-foreground hover:text-foreground"
-						onClick={handleBackToScenarios}
-						type="button"
-					>
-						&larr; Back to scenarios
-					</button>
-					<div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-						<h2 className="text-2xl">{activeScenario.title}</h2>
+	if (activeScenario) {
+		arenaContent = (
+			<div>
+				<button
+					className="mb-6 text-sm text-muted-foreground hover:text-foreground"
+					onClick={handleBackToScenarios}
+					type="button"
+				>
+					&larr; Back to scenarios
+				</button>
+				<div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+					<h2 className="text-2xl">{activeScenario.title}</h2>
+					{canRerollScenarioRuns ? (
 						<button
 							className="text-sm text-muted-foreground hover:text-foreground"
 							onClick={handleRerollScenario}
@@ -138,31 +157,104 @@ function ArenaPage() {
 						>
 							New Scenario Run
 						</button>
-					</div>
-					<ClientOnly
-						fallback={<p className="text-muted-foreground">Loading...</p>}
-					>
-						<ScenarioPlayer
-							key={`${activeScenario.id}:${activeScenario.runSeed ?? "legacy"}`}
-							onComplete={() =>
-								completeScenario(getScenarioProgressKey(activeScenario))
-							}
-							scenario={activeScenario}
-						/>
-					</ClientOnly>
-				</div>
-			) : (
-				<div className="space-y-4">
-					<div className="flex justify-end">
-						<button
+					) : (
+						<a
 							className="text-sm text-muted-foreground hover:text-foreground"
-							onClick={handleShuffleScenarios}
-							type="button"
+							href="/settings#paid-access"
 						>
-							Shuffle Scenario Order
-						</button>
-					</div>
-					{cards.map((scenario) => (
+							Unlock New Scenario Runs (Pro)
+						</a>
+					)}
+				</div>
+				<ClientOnly
+					fallback={<p className="text-muted-foreground">Loading...</p>}
+				>
+					<ScenarioPlayer
+						key={`${activeScenario.id}:${activeScenario.runSeed ?? "legacy"}`}
+						onComplete={() =>
+							completeScenario(getScenarioProgressKey(activeScenario))
+						}
+						scenario={activeScenario}
+					/>
+				</ClientOnly>
+			</div>
+		);
+	} else if (activeScenarioLocked) {
+		arenaContent = (
+			<div className="space-y-5 rounded-lg border border-border p-6">
+				<div className="flex items-center gap-2 text-sm text-muted-foreground">
+					<Lock className="h-4 w-4" />
+					<span>Advanced Scenario Depth (Pro)</span>
+				</div>
+				<h2 className="text-2xl">{activeCard?.title ?? "Locked Scenario"}</h2>
+				<p className="text-muted-foreground">
+					This advanced scenario ladder is locked on Free. Public learning
+					content stays available, and Pro unlocks deeper review-mode incident
+					runs.
+				</p>
+				<div className="flex flex-wrap gap-3">
+					<a
+						className="inline-flex items-center rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
+						href="/settings#paid-access"
+					>
+						View Paid Access Options
+					</a>
+					<button
+						className="text-sm text-muted-foreground hover:text-foreground"
+						onClick={handleBackToScenarios}
+						type="button"
+					>
+						Back to scenarios
+					</button>
+				</div>
+			</div>
+		);
+	} else {
+		arenaContent = (
+			<div className="space-y-4">
+				<div className="flex justify-end">
+					<button
+						className="text-sm text-muted-foreground hover:text-foreground"
+						onClick={handleShuffleScenarios}
+						type="button"
+					>
+						Shuffle Scenario Order
+					</button>
+				</div>
+				{cards.map((scenario) =>
+					scenario.isLocked ? (
+						<Card className="border-border/70 bg-muted/30" key={scenario.id}>
+							<CardHeader className="flex flex-row items-center gap-4">
+								<div className="flex-1">
+									<div className="mb-1 flex items-center gap-2">
+										<CardTitle className="text-base font-semibold">
+											{scenario.title}
+										</CardTitle>
+										<span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+											{scenario.difficulty}
+										</span>
+										{scenario.requiresPremiumDepth && (
+											<span className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
+												Pro
+											</span>
+										)}
+									</div>
+								</div>
+								<Lock className="h-4 w-4 text-muted-foreground" />
+							</CardHeader>
+							<CardContent className="space-y-3">
+								<p className="text-sm text-muted-foreground">
+									{scenario.summary}
+								</p>
+								<a
+									className="inline-flex items-center text-sm text-bl-red hover:underline"
+									href="/settings#paid-access"
+								>
+									Unlock advanced scenario depth
+								</a>
+							</CardContent>
+						</Card>
+					) : (
 						<button
 							className="w-full text-left"
 							key={scenario.id}
@@ -194,9 +286,20 @@ function ArenaPage() {
 								</CardContent>
 							</Card>
 						</button>
-					))}
-				</div>
-			)}
+					)
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div className="container mx-auto max-w-4xl px-4 py-16">
+			<h1 className="mb-4">Incident Arena</h1>
+			<p className="mb-10 max-w-2xl text-lg text-muted-foreground">
+				Realistic carrier integration incidents. Make decisions, get feedback,
+				and build troubleshooting instincts.
+			</p>
+			{arenaContent}
 		</div>
 	);
 }

--- a/src/routes/lesson/$slug.tsx
+++ b/src/routes/lesson/$slug.tsx
@@ -13,6 +13,7 @@ import {
 	fallbackFreeEntitlements,
 } from "@/lib/entitlements/access-policy";
 import { getCurrentEntitlements } from "@/lib/entitlements/entitlements.sync";
+import { captureException } from "@/lib/observability/logger";
 import { completeDrill, completeLesson } from "@/lib/progress/progress.actions";
 import { makeClientSeed } from "@/lib/randomization";
 import { generateCanonical, generateMeta } from "@/lib/seo/meta";
@@ -51,7 +52,11 @@ export const Route = createFileRoute("/lesson/$slug")({
 			const entitlements = await getCurrentEntitlements();
 			capabilities = entitlements.capabilities;
 		} catch (error) {
-			console.error("Failed to resolve lesson entitlements", error);
+			captureException(error, {
+				fallbackTier: "free",
+				operation: "resolve_entitlements",
+				route: "/lesson/$slug",
+			});
 		}
 
 		return {

--- a/src/routes/lesson/$slug.tsx
+++ b/src/routes/lesson/$slug.tsx
@@ -8,6 +8,11 @@ import {
 	getLessonRuntimeBySlug,
 	getRouteSeed,
 } from "@/content/runtime";
+import {
+	canUseLessonChallengeReroll,
+	fallbackFreeEntitlements,
+} from "@/lib/entitlements/access-policy";
+import { getCurrentEntitlements } from "@/lib/entitlements/entitlements.sync";
 import { completeDrill, completeLesson } from "@/lib/progress/progress.actions";
 import { makeClientSeed } from "@/lib/randomization";
 import { generateCanonical, generateMeta } from "@/lib/seo/meta";
@@ -30,7 +35,7 @@ export const Route = createFileRoute("/lesson/$slug")({
 		exclude: search.exclude,
 		seed: search.seed,
 	}),
-	loader: ({ deps, params }) => {
+	loader: async ({ deps, params }) => {
 		const seed = getRouteSeed(`lesson:${params.slug}`, deps.seed);
 		const lessonRuntime = getLessonRuntimeBySlug(params.slug, seed, {
 			excludeDrillIds: deps.exclude
@@ -41,7 +46,18 @@ export const Route = createFileRoute("/lesson/$slug")({
 			throw new Error(`Lesson not found: ${params.slug}`);
 		}
 
-		return lessonRuntime;
+		let capabilities = fallbackFreeEntitlements().capabilities;
+		try {
+			const entitlements = await getCurrentEntitlements();
+			capabilities = entitlements.capabilities;
+		} catch (error) {
+			console.error("Failed to resolve lesson entitlements", error);
+		}
+
+		return {
+			...lessonRuntime,
+			canUseChallengeReroll: canUseLessonChallengeReroll(capabilities),
+		};
 	},
 	head: ({ loaderData }) => {
 		const lesson = loaderData?.lesson;
@@ -67,7 +83,7 @@ export const Route = createFileRoute("/lesson/$slug")({
 
 function LessonPage() {
 	const navigate = useNavigate({ from: "/lesson/$slug" });
-	const { lesson, drills, seed } = Route.useLoaderData();
+	const { canUseChallengeReroll, lesson, drills, seed } = Route.useLoaderData();
 	const [challengeSeed, setChallengeSeed] = useState(seed);
 	const [challengeDrills, setChallengeDrills] = useState(drills);
 	const lessonCatalog = getLessonCatalog();
@@ -103,6 +119,10 @@ function LessonPage() {
 	}, [drills, seed]);
 
 	function handleNewVariantRun() {
+		if (!canUseChallengeReroll) {
+			return;
+		}
+
 		const nextSeed = makeClientSeed(`lesson:${lesson.slug}`);
 		const rerolled = getLessonRuntimeBySlug(lesson.slug, nextSeed, {
 			excludeDrillIds: challengeDrills.map((drill) => drill.id),
@@ -163,9 +183,19 @@ function LessonPage() {
 								</Button>
 							}
 						>
-							<Button onClick={handleNewVariantRun} size="sm" variant="outline">
-								New Challenge
-							</Button>
+							{canUseChallengeReroll ? (
+								<Button
+									onClick={handleNewVariantRun}
+									size="sm"
+									variant="outline"
+								>
+									New Challenge
+								</Button>
+							) : (
+								<Button asChild size="sm" variant="outline">
+									<a href="/settings#paid-access">Unlock New Challenge (Pro)</a>
+								</Button>
+							)}
 						</ClientOnly>
 					</div>
 					<div className="space-y-8">

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -16,6 +16,7 @@ import {
 	TIER_CAPABILITY_MATRIX,
 } from "@/lib/entitlements/access-policy";
 import { getCurrentEntitlements } from "@/lib/entitlements/entitlements.sync";
+import { captureException } from "@/lib/observability/logger";
 import { resetProgress } from "@/lib/progress/progress.actions";
 import { parseProgress } from "@/lib/progress/progress.schema";
 import { saveProgress } from "@/lib/progress/progress.storage";
@@ -101,7 +102,11 @@ function SettingsPanel() {
 				setCurrentEntitlements(entitlements);
 			})
 			.catch((error: unknown) => {
-				console.error("Failed to load entitlement data", error);
+				captureException(error, {
+					fallbackTier: "free",
+					operation: "resolve_entitlements",
+					route: "/settings",
+				});
 				setCurrentEntitlements(fallbackFreeEntitlements());
 			});
 	}, [debugSessionKey]);
@@ -178,7 +183,10 @@ function SettingsPanel() {
 			URL.revokeObjectURL(url);
 			setAccountExportStatus("Account export downloaded.");
 		} catch (error) {
-			console.error("Failed to export account data", error);
+			captureException(error, {
+				operation: "account_privacy_export",
+				route: "/settings",
+			});
 			setAccountExportStatus(
 				"Could not export account data. Contact support if the problem persists."
 			);

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -11,6 +11,10 @@ import {
 } from "@/content/legal";
 import { getAccountPrivacyExport } from "@/lib/account/account-rights.sync";
 import { authClient } from "@/lib/auth/client";
+import {
+	fallbackFreeEntitlements,
+	TIER_CAPABILITY_MATRIX,
+} from "@/lib/entitlements/access-policy";
 import { getCurrentEntitlements } from "@/lib/entitlements/entitlements.sync";
 import { resetProgress } from "@/lib/progress/progress.actions";
 import { parseProgress } from "@/lib/progress/progress.schema";
@@ -70,7 +74,7 @@ function SettingsPanel() {
 		null
 	);
 	const [isExportingAccount, setIsExportingAccount] = useState(false);
-	const [entitlementDebug, setEntitlementDebug] = useState<{
+	const [currentEntitlements, setCurrentEntitlements] = useState<{
 		capabilities: string[];
 		source: string;
 		tier: string;
@@ -88,22 +92,25 @@ function SettingsPanel() {
 		: (session.data?.user?.id ?? "anonymous");
 
 	useEffect(() => {
-		if (!import.meta.env.DEV || debugSessionKey === "pending") {
+		if (debugSessionKey === "pending") {
 			return;
 		}
 
 		getCurrentEntitlements()
 			.then((entitlements) => {
-				setEntitlementDebug(entitlements);
+				setCurrentEntitlements(entitlements);
 			})
 			.catch((error: unknown) => {
-				console.error("Failed to load entitlement debug info", error);
+				console.error("Failed to load entitlement data", error);
+				setCurrentEntitlements(fallbackFreeEntitlements());
 			});
 	}, [debugSessionKey]);
 
 	const completedLessons = Object.values(lessonsProgress).filter(
 		(l) => l.completed
 	).length;
+	const activeTier = currentEntitlements?.tier ?? "free";
+	const hasPaidTier = activeTier === "pro" || activeTier === "enterprise";
 
 	function handleExport() {
 		const data = progressStore.state;
@@ -276,6 +283,63 @@ function SettingsPanel() {
 				)}
 			</div>
 
+			<div className="space-y-4" id="paid-access">
+				<h2 className="text-xl">Plans and Access</h2>
+				<p className="max-w-3xl text-sm text-muted-foreground">
+					Public lessons, wiki, and directory pages stay crawlable. Paid tiers
+					add challenge depth, review-mode access, and premium account surfaces
+					without blanketing public educational content.
+				</p>
+				<div className="grid gap-4 md:grid-cols-3">
+					{TIER_CAPABILITY_MATRIX.map((tier) => (
+						<Card key={tier.tier}>
+							<CardHeader>
+								<CardTitle>{tier.label}</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<ul className="space-y-2 text-sm text-muted-foreground">
+									{tier.surfaces.map((surface) => (
+										<li key={surface}>{surface}</li>
+									))}
+								</ul>
+							</CardContent>
+						</Card>
+					))}
+				</div>
+				<Card>
+					<CardHeader>
+						<CardTitle>Current entitlement state</CardTitle>
+					</CardHeader>
+					<CardContent className="space-y-3 text-sm text-muted-foreground">
+						<p>
+							Current tier:{" "}
+							<strong className="text-foreground">{activeTier}</strong>
+						</p>
+						<p>
+							Source:{" "}
+							<strong className="text-foreground">
+								{currentEntitlements?.source ?? "fallback_free"}
+							</strong>
+						</p>
+						{hasPaidTier ? (
+							<p>
+								Your account has paid-tier access enabled. Premium challenge
+								surfaces should be unlocked across lessons and arena.
+							</p>
+						) : (
+							<p>
+								No active paid entitlement is detected. Missing, inactive, or
+								canceled subscriptions safely remain on Free access until a paid
+								entitlement becomes active.
+							</p>
+						)}
+						<a className="text-bl-red hover:underline" href={supportMailto}>
+							Contact support for Pro or Enterprise access
+						</a>
+					</CardContent>
+				</Card>
+			</div>
+
 			<div className="space-y-4">
 				<h2 className="text-xl">Account Data Rights</h2>
 				<div className="grid gap-4 md:grid-cols-2">
@@ -380,17 +444,17 @@ function SettingsPanel() {
 				</div>
 			</div>
 
-			{import.meta.env.DEV && entitlementDebug && (
+			{import.meta.env.DEV && currentEntitlements && (
 				<div className="space-y-3 rounded-lg border border-border p-4">
 					<h2 className="text-xl">Entitlement Debug</h2>
 					<p className="text-sm text-muted-foreground">
 						User: {session.data?.user?.email ?? "anonymous"}
 					</p>
 					<p className="text-sm text-muted-foreground">
-						Tier: {entitlementDebug.tier} ({entitlementDebug.source})
+						Tier: {currentEntitlements.tier} ({currentEntitlements.source})
 					</p>
 					<pre className="overflow-auto rounded bg-muted p-3 text-xs">
-						{JSON.stringify(entitlementDebug.capabilities, null, 2)}
+						{JSON.stringify(currentEntitlements.capabilities, null, 2)}
 					</pre>
 				</div>
 			)}

--- a/tests/browser/smoke.spec.ts
+++ b/tests/browser/smoke.spec.ts
@@ -9,6 +9,8 @@ const START_REST_TRACK = /start rest track/i;
 const START_SOAP_TRACK = /start soap track/i;
 const INCIDENT_ARENA = /incident arena/i;
 const SETTINGS = /settings/i;
+const PLANS_AND_ACCESS = /plans and access/i;
+const CURRENT_ENTITLEMENT_STATE = /current entitlement state/i;
 const ACCOUNT_DATA_RIGHTS = /account data rights/i;
 const ACCESS_AND_EXPORT = /access and export/i;
 const DELETION_REQUESTS = /deletion requests/i;
@@ -28,7 +30,7 @@ const CARRIER_CAPABILITY_MATRIX = /carrier capability matrix/i;
 const SANDBOX_VS_PRODUCTION_BEHAVIOR = /sandbox vs production behavior/i;
 const PRACTICE_DRILLS = /practice drills/i;
 const MARK_LESSON_COMPLETE = /mark lesson complete/i;
-const NEW_CHALLENGE = /new challenge/i;
+const UNLOCK_NEW_CHALLENGE_PRO = /unlock new challenge \(pro\)/i;
 const CHECK_ANSWER = /check answer/i;
 const ACCEPT_COOKIES =
 	/accept cookies|accept all|allow analytics|manage cookies/i;
@@ -37,6 +39,7 @@ const DUPLICATE_WEBHOOK_REPLAY = /duplicate webhook replay/i;
 const SOAP_HEADER_AUTH_MISMATCH = /soap header\/auth mismatch/i;
 const SANDBOX_WORKS_BUT_PRODUCTION_REJECTS =
 	/sandbox works but production rejects the request/i;
+const UNLOCK_ADVANCED_SCENARIO_DEPTH = /unlock advanced scenario depth/i;
 const BACK_TO_SCENARIOS = /back to scenarios/i;
 const SCHEMA_VALIDATION = /schema validation/i;
 const SOURCES_HEADING = /^Sources$/;
@@ -106,6 +109,8 @@ test("settings exposes the privacy and account-rights surfaces", async ({
 	await expect(
 		page.getByRole("heading", { level: 1, name: SETTINGS })
 	).toBeVisible();
+	await expect(page.getByText(PLANS_AND_ACCESS)).toBeVisible();
+	await expect(page.getByText(CURRENT_ENTITLEMENT_STATE)).toBeVisible();
 	await expect(page.getByText(ACCOUNT_DATA_RIGHTS)).toBeVisible();
 	await expect(page.getByText(ACCESS_AND_EXPORT)).toBeVisible();
 	await expect(page.getByText(DELETION_REQUESTS)).toBeVisible();
@@ -202,7 +207,7 @@ test("cross-track hub renders the final wave 4 lesson set", async ({
 	).toBeVisible();
 });
 
-test("wave 4 cross-track lesson route resets answers and rerolls new drill variants", async ({
+test("wave 4 cross-track lesson route keeps drills visible and gates premium rerolls for free tier", async ({
 	page,
 }) => {
 	await page.goto(
@@ -218,19 +223,9 @@ test("wave 4 cross-track lesson route resets answers and rerolls new drill varia
 	await expect(
 		page.getByRole("heading", { name: PRACTICE_DRILLS })
 	).toBeVisible();
-	const newChallengeButton = page.getByRole("button", { name: NEW_CHALLENGE });
-	await expect(newChallengeButton).toBeEnabled();
-	const questionPrompts = page.locator("main p.font-medium.text-foreground");
-	const beforeQuestions = await questionPrompts.allTextContents();
-
-	await newChallengeButton.click();
-	await expect(questionPrompts).toHaveCount(2);
-	await expect
-		.poll(async () => questionPrompts.allTextContents())
-		.not.toEqual(beforeQuestions);
-
-	const afterQuestions = await questionPrompts.allTextContents();
-	expect(afterQuestions).not.toEqual(beforeQuestions);
+	await expect(
+		page.getByRole("link", { name: UNLOCK_NEW_CHALLENGE_PRO })
+	).toBeVisible();
 	await expect(
 		page.getByRole("button", { name: CHECK_ANSWER }).first()
 	).toBeDisabled();
@@ -255,7 +250,10 @@ test("arena lists migrated scenario cards and opens a wave 2 incident", async ({
 		page.getByRole("button", { name: SOAP_HEADER_AUTH_MISMATCH })
 	).toBeVisible();
 	await expect(
-		page.getByRole("button", { name: SANDBOX_WORKS_BUT_PRODUCTION_REJECTS })
+		page.getByText(SANDBOX_WORKS_BUT_PRODUCTION_REJECTS)
+	).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: UNLOCK_ADVANCED_SCENARIO_DEPTH }).first()
 	).toBeVisible();
 
 	await page.goto("/arena?scenario=duplicate-webhook-replay&runSeed=123");


### PR DESCRIPTION
Ship the first paid-tier implementation slice with entitlement-aware gating while keeping public educational pages crawlable.

- add a Free/Pro/Enterprise capability matrix and centralized access-policy helpers
- gate premium lesson rerolls and advanced arena scenario depth by capability
- add locked-content and upgrade UX on lesson, arena, and settings surfaces
- preserve safe fallback behavior for missing/inactive/canceled paid state
- add regression tests plus updated browser smoke assertions
- sync README and memory-bank/current-changes artifacts

Refs v1.1.18 #21 I21D1-I21D6
