### PR TITLE
feat(dev-seed): dev-only tiered auth users, billing-shape seed state, and Playwright auth helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,8 @@ CREEM_ENV = XXXXXXXXX
 CREEM_PRO_MONTHLY_PRODUCT_ID = XXXXXXXXX
 CREEM_PRO_ANNUAL_PRODUCT_ID = XXXXXXXXX
 # CREEM_ENTERPRISE_PRODUCT_ID =   # CURRENTLY NOT USED
+
+# Dev-only tiered seed users. Set to "true" locally to opt in to
+# `pnpm seed:dev-users` and the Playwright tiered-auth helpers. The seed
+# command refuses to run in production/preview regardless of this flag.
+# ENABLE_DEV_SEED = true

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ admin/
 
 # Newsletter PII data (Phase 1 JSON storage)
 content/newsletter/subscribers.json
+
+# Dev-only tiered auth artifacts (seed credentials + Playwright storage states)
+.playwright-auth/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,38 @@ pnpm dev
 
 Open `http://localhost:3000`.
 
+## Dev-Only Tiered Auth Users
+
+For testing entitlement-gated surfaces locally, the repo ships a guarded
+seed command that creates deterministic Free/Pro/Enterprise/canceled/
+past-due users via Better Auth plus billing-shaped `subscriptions` rows.
+The entitlement resolver uses the same code path as production when
+reading these rows — the seed never bypasses resolution with manual
+grants.
+
+```bash
+# .env.local
+ENABLE_DEV_SEED=true
+DATABASE_URL=postgres://...   # local dev database only
+
+pnpm seed:dev-users
+```
+
+Outputs:
+
+- `.playwright-auth/credentials.json` — seeded user credentials (gitignored)
+- Playwright tiered-auth tests in `tests/browser/tiered-auth.spec.ts`
+  automatically pick up the file and run; they skip cleanly if it is
+  missing (e.g. CI without a seeded database).
+
+The seed command refuses to run unless `NODE_ENV` is `development` or
+`test`, `VERCEL_ENV` is not `production`/`preview`, `ENABLE_DEV_SEED=true`,
+and `DATABASE_URL` is set. The fixture definitions live in
+`src/lib/dev/seed-fixtures.ts` and include one Free, one Pro, one
+Enterprise, one canceled, and one past-due user. Canceled and past-due
+fixtures assert that the resolver falls back to Free instead of masking
+the state.
+
 ## Testing
 
 - `pnpm test` runs the Vitest unit and integration suite.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "generate:og": "node scripts/generate-og-images.mjs",
+    "seed:dev-users": "tsx scripts/seed-dev-users.ts",
     "format": "biome format --write",
     "lint": "biome lint",
     "check": "biome check"
@@ -89,6 +90,7 @@
     "baseline-browser-mapping": "^2.10.0",
     "drizzle-kit": "^0.31.10",
     "jsdom": "^27.0.0",
+    "tsx": "^4.20.2",
     "typescript": "^5.9.3",
     "ultracite": "7.3.2",
     "vite": "^7.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       jsdom:
         specifier: ^27.0.0
         version: 27.2.0
+      tsx:
+        specifier: ^4.20.2
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/scripts/seed-dev-users.ts
+++ b/scripts/seed-dev-users.ts
@@ -1,0 +1,55 @@
+/**
+ * Dev-only tiered seed CLI.
+ *
+ * Run with:
+ *   pnpm seed:dev-users
+ *
+ * Guarded by `src/lib/dev/seed-guard.ts` — the script refuses to run unless
+ * NODE_ENV is `development` or `test`, VERCEL_ENV is not production or
+ * preview, `ENABLE_DEV_SEED=true`, and DATABASE_URL is set. The script
+ * writes the seeded credentials to `.playwright-auth/credentials.json` so
+ * the Playwright tiered-auth helpers can discover them.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { closeDbPool } from "@/lib/db/client";
+import { seedDevUsers } from "@/lib/dev/seed-dev-users";
+
+const OUTPUT_PATH = resolve(
+	process.cwd(),
+	".playwright-auth",
+	"credentials.json"
+);
+
+async function main(): Promise<void> {
+	const result = await seedDevUsers(process.env);
+	mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+	const payload = {
+		generatedAt: new Date().toISOString(),
+		entries: result.entries,
+	};
+	writeFileSync(OUTPUT_PATH, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+
+	for (const entry of result.entries) {
+		const status = entry.created ? "created" : "existing";
+		const subscription = entry.subscriptionId
+			? ` subscription=${entry.subscriptionId}`
+			: "";
+		console.log(
+			`[seed-dev-users] ${entry.key} (${status}) email=${entry.email} tier=${entry.expectedTier}${subscription}`
+		);
+	}
+
+	console.log(`[seed-dev-users] credentials written to ${OUTPUT_PATH}`);
+}
+
+main()
+	.catch((error) => {
+		console.error("[seed-dev-users] failed:", error);
+		process.exitCode = 1;
+	})
+	.finally(async () => {
+		await closeDbPool();
+	});

--- a/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
+++ b/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
@@ -75,3 +75,7 @@ The seed implementation should use Better Auth-supported account creation where 
 ## PR #30 Gemini Review Follow-ups (1.2.3)
 
 - Added `userId` and `provider: "dev-seed"` to the `subscriptions.onConflictDoUpdate` set clause in `upsertSubscriptionForFixture`, ensuring the subscription row is correctly reassigned if a row with the same deterministic `dev-seed-{fixture.key}` ID was previously associated with a different user.
+
+## PR #30 Gemini Review Follow-ups (1.2.4)
+
+- Added duration calculation based on plan type in `upsertSubscriptionForFixture` so annual plans use 365 days and monthly plans use 30 days, ensuring the seeded data matches the expected billing shape for both `active_pro_monthly` and `active_pro_annual` fixtures.

--- a/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
+++ b/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
@@ -58,3 +58,11 @@ The seed implementation should use Better Auth-supported account creation where 
 - `tests/browser/tiered-auth.spec.ts` exercises the gated lesson-reroll surface and the `/settings` entitlement debug panel for each tier; it auto-skips when credentials are not seeded so CI without a database stays green.
 - `src/lib/dev/seed-dev-users.test.ts` covers the guard reasons and asserts the resolver returns the expected tier for every fixture state.
 - README documents the opt-in steps (`ENABLE_DEV_SEED=true`, `pnpm seed:dev-users`, `pnpm test:e2e`) and the fallback guarantees for canceled/past-due states.
+
+## PR #30 Gemini Review Follow-ups (1.2.1)
+
+- `DEV_TIER_PASSWORD` is now overridable via the `DEV_TIER_PASSWORD` env var (default kept for zero-config local use); the seed guard still blocks hosted environments regardless.
+- `isDevSeedInProgress` in `@/src/lib/email/lifecycle.ts` short-circuits `sendLifecycleEmail` when `DEV_SEED_IN_PROGRESS=true`; `seedDevUsers` sets the flag around its run and restores the previous value through `Reflect.deleteProperty`. The Better Auth `databaseHooks.user.create.after` path still runs end-to-end; only the outbound Resend call is suppressed.
+- `subscriptions.onConflictDoUpdate` now includes `priceId: null` in its `set` block so a stale `priceId` in a previously seeded row cannot drift from the canonical fixture shape.
+- Fixture processing runs in parallel via `Promise.all(DEV_TIER_KEYS.map(seedEntryForKey))`; unique emails and unique `dev-seed-${key}` subscription ids keep the atomic upserts contention-free.
+- Added 2 regression tests for the strict `"true"` exact-match contract of `isDevSeedInProgress`.

--- a/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
+++ b/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
@@ -66,3 +66,8 @@ The seed implementation should use Better Auth-supported account creation where 
 - `subscriptions.onConflictDoUpdate` now includes `priceId: null` in its `set` block so a stale `priceId` in a previously seeded row cannot drift from the canonical fixture shape.
 - Fixture processing runs in parallel via `Promise.all(DEV_TIER_KEYS.map(seedEntryForKey))`; unique emails and unique `dev-seed-${key}` subscription ids keep the atomic upserts contention-free.
 - Added 2 regression tests for the strict `"true"` exact-match contract of `isDevSeedInProgress`.
+
+## PR #30 Gemini Review Follow-ups (1.2.2)
+
+- Wrapped `auth.api.signUpEmail` in `src/lib/dev/seed-dev-users.ts` with a `try`/`catch` that rethrows with fixture context and forwards the underlying Better Auth `APIError` through the standard `Error(..., { cause })` option, so password-complexity, unique-constraint, and transient DB failures preserve their original message and stack.
+- The empty-`userId` fallback now also stringifies the response payload, making failed seed runs diagnosable without extra logging.

--- a/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
+++ b/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
@@ -79,3 +79,9 @@ The seed implementation should use Better Auth-supported account creation where 
 ## PR #30 Gemini Review Follow-ups (1.2.4)
 
 - Added duration calculation based on plan type in `upsertSubscriptionForFixture` so annual plans use 365 days and monthly plans use 30 days, ensuring the seeded data matches the expected billing shape for both `active_pro_monthly` and `active_pro_annual` fixtures.
+
+## PR #30 Gemini Review Follow-ups (1.2.5)
+
+- Moved duration into `SubscriptionSeedShape` as explicit `periodDays` field with `MS_PER_DAY` constant, removing fragile string matching against plan keys.
+- Kept `process.env` for flag manipulation since `SeedGuardEnv` has a readonly index signature; the `env` parameter is only used for the guard check while the actual signal uses the global.
+- Removed redundant nullish coalescing operators in `tests/browser/fixtures/tiered-auth.ts` since `CredentialEntry` guarantees email and password are strings.

--- a/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
+++ b/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
@@ -3,7 +3,7 @@
 Issue: [#27](https://github.com/BallLightningAB/shipping-api-dojo/issues/27)
 Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
 Milestone: v2
-Status: planned
+Status: implemented (pending validation)
 
 ## Goal
 
@@ -47,3 +47,14 @@ Provide a safe development-only way to test Free, Pro, Enterprise, canceled, and
 ## Notes
 
 The seed implementation should use Better Auth-supported account creation where practical and direct Drizzle writes only for billing/subscription fixtures. Manual entitlement rows must not accidentally mask canceled or inactive subscription fallback behavior.
+
+## Implementation Summary
+
+- `src/lib/dev/seed-guard.ts` centralizes the environment gate: requires NODE_ENV in {development, test}, blocks VERCEL_ENV in {production, preview}, requires `ENABLE_DEV_SEED=true`, and requires `DATABASE_URL`.
+- `src/lib/dev/seed-fixtures.ts` defines the five canonical fixtures (`free`, `pro`, `enterprise`, `canceled`, `inactive`) plus the billing-shape resolver that maps a fixture state to a `subscriptions` row.
+- `src/lib/dev/seed-dev-users.ts` performs idempotent sign-up via `auth.api.signUpEmail` and an `onConflictDoUpdate` upsert into the `subscriptions` table. Free fixtures explicitly delete stray subscription rows so the Free fallback is real, not manual.
+- `scripts/seed-dev-users.ts` is the CLI entry point invoked with `pnpm seed:dev-users`. It writes credentials to `.playwright-auth/credentials.json` (gitignored).
+- `tests/browser/fixtures/tiered-auth.ts` signs in via Better Auth's email/password endpoint and persists Playwright storage state files per tier.
+- `tests/browser/tiered-auth.spec.ts` exercises the gated lesson-reroll surface and the `/settings` entitlement debug panel for each tier; it auto-skips when credentials are not seeded so CI without a database stays green.
+- `src/lib/dev/seed-dev-users.test.ts` covers the guard reasons and asserts the resolver returns the expected tier for every fixture state.
+- README documents the opt-in steps (`ENABLE_DEV_SEED=true`, `pnpm seed:dev-users`, `pnpm test:e2e`) and the fallback guarantees for canceled/past-due states.

--- a/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
+++ b/specs/current-changes/issue-27-dev-tier-seeded-users-plan.md
@@ -71,3 +71,7 @@ The seed implementation should use Better Auth-supported account creation where 
 
 - Wrapped `auth.api.signUpEmail` in `src/lib/dev/seed-dev-users.ts` with a `try`/`catch` that rethrows with fixture context and forwards the underlying Better Auth `APIError` through the standard `Error(..., { cause })` option, so password-complexity, unique-constraint, and transient DB failures preserve their original message and stack.
 - The empty-`userId` fallback now also stringifies the response payload, making failed seed runs diagnosable without extra logging.
+
+## PR #30 Gemini Review Follow-ups (1.2.3)
+
+- Added `userId` and `provider: "dev-seed"` to the `subscriptions.onConflictDoUpdate` set clause in `upsertSubscriptionForFixture`, ensuring the subscription row is correctly reassigned if a row with the same deterministic `dev-seed-{fixture.key}` ID was previously associated with a different user.

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,8 +1,44 @@
 entries:
   - date: "2026-04-23"
-    version: "1.2.0"
+    version: "1.2.1"
     commit: TBD
     status: pending
+    title: "fix(dev-seed): PR #30 Gemini review — env-overridable password, lifecycle-email suppression, full priceId reset, and parallel seeding"
+    details: |-
+      Addressed the four Gemini review comments on PR #30 for issue #27
+      (I5D12) on `codex/issue-27-dev-tier-seeded-users`.
+
+      - Allow `DEV_TIER_PASSWORD` to be overridden via env in
+        `src/lib/dev/seed-fixtures.ts` so shared dev databases do not rely on
+        the source-controlled default. The seed guard still blocks production
+        and preview regardless of the flag
+      - Suppress outbound lifecycle emails during dev-tier seeding. Added
+        `isDevSeedInProgress` in `src/lib/email/lifecycle.ts` that short-circuits
+        `sendLifecycleEmail` with a `console.warn` when `DEV_SEED_IN_PROGRESS=true`,
+        and wrapped `seedDevUsers` so it sets the flag around its run and
+        restores the previous value via `Reflect.deleteProperty`. The Better
+        Auth `databaseHooks.user.create.after` welcome-email hook still
+        executes end-to-end; only the Resend network call is skipped, so dummy
+        addresses cannot bounce or consume quota
+      - Include `priceId: null` in the `subscriptions` `onConflictDoUpdate`
+        `set` block so reruns fully reset the billing shape even if a
+        previously-seeded row held a stale `priceId`
+      - Parallelize the fixture loop via `Promise.all(DEV_TIER_KEYS.map(seedEntryForKey))`
+        after extracting a `seedEntryForKey` helper. Each fixture targets a
+        unique `email` and a unique `subscriptionId`, so the atomic upserts
+        cannot contend, and the seed command remains a single-runner CLI
+      - Added 2 regression tests in `src/lib/dev/seed-dev-users.test.ts`
+        covering the strict `"true"` exact-match contract of
+        `isDevSeedInProgress`
+      - Replied to and resolved all four Gemini review threads on PR #30
+    refs:
+      - "I5D12"
+      - "#27"
+      - "#30"
+  - date: "2026-04-23"
+    version: "1.2.0"
+    commit: 250f775
+    status: completed
     title: "feat(dev-seed): dev-only tiered auth users, billing-shape seed state, and Playwright auth helpers"
     details: |-
       Implemented issue #27 (I5D12) on `codex/issue-27-dev-tier-seeded-users` to

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,5 +1,27 @@
 entries:
   - date: "2026-04-23"
+    version: "1.2.3"
+    commit: TBD
+    status: pending
+    title: "fix(dev-seed): PR #30 Gemini follow-up — add userId and provider to upsert set clause"
+    details: |-
+      Addressed the sixth Gemini review comment on PR #30 for issue #27
+      (I5D12).
+
+      - Added `userId` and `provider: "dev-seed"` to the
+        `onConflictDoUpdate` `set` clause in `upsertSubscriptionForFixture`
+        in `src/lib/dev/seed-dev-users.ts`.
+      - The upsert now fully reassigns the subscription row to the correct
+        user if a row with the same deterministic `dev-seed-{fixture.key}`
+        ID was previously associated with a different user, ensuring the
+        billing shape stays consistent with the fixture even across user
+        changes or manual database interventions.
+      - Replied to the sixth PR #30 review thread.
+    refs:
+      - "I5D12"
+      - "#27"
+      - "#30"
+  - date: "2026-04-23"
     version: "1.2.2"
     commit: TBD
     status: pending

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,8 +1,30 @@
 entries:
   - date: "2026-04-23"
-    version: "1.2.1"
+    version: "1.2.2"
     commit: TBD
     status: pending
+    title: "fix(dev-seed): PR #30 Gemini follow-up — forward signUpEmail APIError via Error cause"
+    details: |-
+      Addressed the fifth Gemini review comment on PR #30 for issue #27
+      (I5D12).
+
+      - Wrapped `auth.api.signUpEmail` in a `try`/`catch` in
+        `src/lib/dev/seed-dev-users.ts` so Better Auth's `APIError` (password
+        complexity, unique-constraint, transient DB) is rethrown with fixture
+        context while preserving the original message and stack via the
+        standard `Error(..., { cause })` option.
+      - The empty-`userId` fallback now also stringifies the full response
+        payload in the error message, so failed seed runs surface the exact
+        Better Auth response shape without extra logging.
+      - Replied to and resolved the fifth PR #30 review thread.
+    refs:
+      - "I5D12"
+      - "#27"
+      - "#30"
+  - date: "2026-04-23"
+    version: "1.2.1"
+    commit: e5876f9
+    status: completed
     title: "fix(dev-seed): PR #30 Gemini review — env-overridable password, lifecycle-email suppression, full priceId reset, and parallel seeding"
     details: |-
       Addressed the four Gemini review comments on PR #30 for issue #27

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,4 +1,39 @@
 entries:
+  - date: "2026-04-23"
+    version: "1.2.0"
+    commit: TBD
+    status: pending
+    title: "feat(dev-seed): dev-only tiered auth users, billing-shape seed state, and Playwright auth helpers"
+    details: |-
+      Implemented issue #27 (I5D12) on `codex/issue-27-dev-tier-seeded-users` to
+      unblock rigorous testing of the paid-tier flows planned for I5D9.
+
+      - Added `src/lib/dev/seed-guard.ts` centralizing the environment gate:
+        allows NODE_ENV in {development, test}, blocks VERCEL_ENV in
+        {production, preview}, requires `ENABLE_DEV_SEED=true`, and requires
+        `DATABASE_URL` so the real resolver path is exercised
+      - Added `src/lib/dev/seed-fixtures.ts` with the five canonical dev users
+        (free, pro, enterprise, canceled, inactive) and a pure resolver that
+        maps each state to a billing-shape subscription row
+      - Added `src/lib/dev/seed-dev-users.ts` which performs idempotent
+        `auth.api.signUpEmail` sign-ups and `onConflictDoUpdate` upserts into
+        `subscriptions`. Free fixtures delete stray subscription rows so the
+        Free fallback path is real, not manually granted
+      - Added `scripts/seed-dev-users.ts` CLI plus the `pnpm seed:dev-users`
+        script and a `tsx` devDep; credentials are written to
+        `.playwright-auth/credentials.json` (gitignored)
+      - Added `tests/browser/fixtures/tiered-auth.ts` helpers that sign in via
+        Better Auth's email/password endpoint and persist Playwright storage
+        state per tier, plus `tests/browser/tiered-auth.spec.ts` which
+        auto-skips when credentials are missing so CI without a seeded DB
+        stays green
+      - Added `src/lib/dev/seed-dev-users.test.ts` covering all six guard
+        branches plus resolver expectations for every fixture state
+      - Documented the opt-in flow in README and `.env.example`, and updated
+        the issue plan and memory bank to mark I5D12 complete
+    refs:
+      - "I5D12"
+      - "#27"
   - date: "2026-04-22"
     version: "1.1.35"
     commit: e5ddc43

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,5 +1,25 @@
 entries:
   - date: "2026-04-23"
+    version: "1.2.4"
+    commit: TBD
+    status: pending
+    title: "fix(dev-seed): PR #30 Gemini follow-up — calculate subscription duration by plan type"
+    details: |-
+      Addressed the seventh Gemini review comment on PR #30 for issue #27
+      (I5D12).
+
+      - Added duration calculation based on plan type in
+        `upsertSubscriptionForFixture` in `src/lib/dev/seed-dev-users.ts`.
+      - Annual plans (`planKey.includes("annual")`) now use 365 days, while
+        monthly plans use 30 days.
+      - This ensures the seeded data matches the expected billing shape for
+        both `active_pro_monthly` and `active_pro_annual` fixtures.
+      - Replied to the seventh PR #30 review thread.
+    refs:
+      - "I5D12"
+      - "#27"
+      - "#30"
+  - date: "2026-04-23"
     version: "1.2.3"
     commit: TBD
     status: pending

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,5 +1,30 @@
 entries:
   - date: "2026-04-23"
+    version: "1.2.5"
+    commit: TBD
+    status: pending
+    title: "refactor(dev-seed): PR #30 Gemini follow-up — explicit periodDays, MS_PER_DAY constant, and cleanup"
+    details: |-
+      Addressed the eighth, ninth, and tenth Gemini review comments on PR #30
+      for issue #27 (I5D12).
+
+      - Added `periodDays` field to `SubscriptionSeedShape` interface in
+        `seed-fixtures.ts`, with each fixture state defining its billing
+        period (30 days for monthly, 365 days for annual/enterprise).
+      - Added `MS_PER_DAY` constant for millisecond conversion instead of
+        magic numbers, removing fragile string matching against plan keys.
+      - Kept `process.env` for flag manipulation since `SeedGuardEnv` has a
+        readonly index signature; the `env` parameter is only used for the
+        guard check while the actual signal uses the global.
+      - Removed redundant nullish coalescing operators in
+        `tests/browser/fixtures/tiered-auth.ts` since `CredentialEntry`
+        guarantees email and password are strings.
+      - Replied to all three PR #30 review threads.
+    refs:
+      - "I5D12"
+      - "#27"
+      - "#30"
+  - date: "2026-04-23"
     version: "1.2.4"
     commit: TBD
     status: pending

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.2.1"
+  release: "1.2.2"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -177,6 +177,8 @@ roadmap:
           note: "Started issue #27 on codex/issue-27-dev-tier-seeded-users: added a guarded dev-only seed command (NODE_ENV development|test, blocks VERCEL_ENV production|preview, requires ENABLE_DEV_SEED=true + DATABASE_URL) that creates deterministic Free/Pro/Enterprise/canceled/past-due users via Better Auth signUpEmail and writes billing-shaped subscription rows so the real resolver path decides the tier. Shipped Playwright storage-state helpers + a tier-gated smoke spec that auto-skips when credentials are not seeded, unit coverage for the guard and fixture-to-resolver mapping, and README/.env.example documentation. This unblocks I5D9 paid-tier checkout and entitlement testing."
         - covers: [I5D12]
           note: "Addressed the four Gemini review comments on PR #30 for issue #27: made DEV_TIER_PASSWORD overridable via env; added a DEV_SEED_IN_PROGRESS signal + isDevSeedInProgress helper in src/lib/email/lifecycle.ts that suppresses the outbound Resend call in sendLifecycleEmail while keeping the Better Auth databaseHooks.user.create.after welcome hook flow intact; included priceId: null in the subscriptions onConflictDoUpdate set clause so reruns fully reset the billing shape; and parallelized seedDevUsers via Promise.all(DEV_TIER_KEYS.map(seedEntryForKey)) with unique per-fixture subscription ids keeping the atomic upserts contention-free. Added regression tests for the strict isDevSeedInProgress exact-match contract; replied to and resolved all four PR #30 review threads."
+        - covers: [I5D12]
+          note: "Addressed the fifth Gemini review comment on PR #30 for issue #27: wrapped auth.api.signUpEmail in a try/catch that rethrows with fixture context and forwards the underlying APIError via the standard Error(..., { cause }) option, preserving the original message and stack for password-complexity, unique-constraint, and transient DB failures; the empty-userId fallback now also stringifies the response payload for diagnosability. Replied to and resolved the PR #30 review thread."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.1.35"
+  release: "1.2.0"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -113,7 +113,7 @@ roadmap:
         - id: dev-tier-seeded-users
           issue: "#27"
           title: "Add dev-only tiered seed users and Playwright auth states"
-          status: planned
+          status: done
           links:
             issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/27"
         - id: seed-security
@@ -127,7 +127,6 @@ roadmap:
         - "[I5D9] Implement entitlement-aware paid tiers, content gating, premium access surfaces, and launch-ready upgrade behavior"
         - "[I5D10] Expand the wiki and directory beyond curriculum support into the v2 carrier reference surface"
         - "[I5D11] Add privacy-safe Sentry Free-tier observability for hosted v2 error paths"
-        - "[I5D12] Add dev-only tiered auth users, billing-shaped seed state, and Playwright auth helpers"
       progress_log:
         - note: "Research captured in specs/current-changes/issue-5-content-expansion-research.md and GitHub issue #5 was updated to target minimum viable randomization, 20 lessons, 20 drill families, and 20 scenario families."
         - note: "Created the issue-5 joint plan plus issue-specific plan artifacts for #7, #11, #8, #9, and #10; added GitHub issue #11 for auth/billing/email/domain foundation; and updated the roadmap to sequence work as #7 -> #11 -> #8 -> #9 with #10 as follow-on."
@@ -174,6 +173,8 @@ roadmap:
           note: "Addressed the twelfth PR #29 review comment for issue #28: reworked the `createPracticeSeedId` fallback to produce an RFC 4122-compliant UUID v4 via the standard version/variant bit masks, and added a unit test that stubs `globalThis.crypto.randomUUID` to drive the fallback path."
         - covers: [I5D13]
           note: "Closed GitHub issue #28 after PR #29 merged to main: removed URL-visible seeds from lesson and arena practice flows, added database-backed practice_seeds ownership keyed by (user_id, surface, scope) with cascade FK, moved Pro rerolls to server-authoritative seed rotation, preserved public lesson/arena content crawlability with anonymous demo practice as non-certificate-bearing, and shipped regression tests verifying seeds are absent from URLs, client payloads, and public page markup."
+        - covers: [I5D12]
+          note: "Started issue #27 on codex/issue-27-dev-tier-seeded-users: added a guarded dev-only seed command (NODE_ENV development|test, blocks VERCEL_ENV production|preview, requires ENABLE_DEV_SEED=true + DATABASE_URL) that creates deterministic Free/Pro/Enterprise/canceled/past-due users via Better Auth signUpEmail and writes billing-shaped subscription rows so the real resolver path decides the tier. Shipped Playwright storage-state helpers + a tier-gated smoke spec that auto-skips when credentials are not seeded, unit coverage for the guard and fixture-to-resolver mapping, and README/.env.example documentation. This unblocks I5D9 paid-tier checkout and entitlement testing."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.2.0"
+  release: "1.2.1"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -175,6 +175,8 @@ roadmap:
           note: "Closed GitHub issue #28 after PR #29 merged to main: removed URL-visible seeds from lesson and arena practice flows, added database-backed practice_seeds ownership keyed by (user_id, surface, scope) with cascade FK, moved Pro rerolls to server-authoritative seed rotation, preserved public lesson/arena content crawlability with anonymous demo practice as non-certificate-bearing, and shipped regression tests verifying seeds are absent from URLs, client payloads, and public page markup."
         - covers: [I5D12]
           note: "Started issue #27 on codex/issue-27-dev-tier-seeded-users: added a guarded dev-only seed command (NODE_ENV development|test, blocks VERCEL_ENV production|preview, requires ENABLE_DEV_SEED=true + DATABASE_URL) that creates deterministic Free/Pro/Enterprise/canceled/past-due users via Better Auth signUpEmail and writes billing-shaped subscription rows so the real resolver path decides the tier. Shipped Playwright storage-state helpers + a tier-gated smoke spec that auto-skips when credentials are not seeded, unit coverage for the guard and fixture-to-resolver mapping, and README/.env.example documentation. This unblocks I5D9 paid-tier checkout and entitlement testing."
+        - covers: [I5D12]
+          note: "Addressed the four Gemini review comments on PR #30 for issue #27: made DEV_TIER_PASSWORD overridable via env; added a DEV_SEED_IN_PROGRESS signal + isDevSeedInProgress helper in src/lib/email/lifecycle.ts that suppresses the outbound Resend call in sendLifecycleEmail while keeping the Better Auth databaseHooks.user.create.after welcome hook flow intact; included priceId: null in the subscriptions onConflictDoUpdate set clause so reruns fully reset the billing shape; and parallelized seedDevUsers via Promise.all(DEV_TIER_KEYS.map(seedEntryForKey)) with unique per-fixture subscription ids keeping the atomic upserts contention-free. Added regression tests for the strict isDevSeedInProgress exact-match contract; replied to and resolved all four PR #30 review threads."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.2.3"
+  release: "1.2.4"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -181,6 +181,8 @@ roadmap:
           note: "Addressed the fifth Gemini review comment on PR #30 for issue #27: wrapped auth.api.signUpEmail in a try/catch that rethrows with fixture context and forwards the underlying APIError via the standard Error(..., { cause }) option, preserving the original message and stack for password-complexity, unique-constraint, and transient DB failures; the empty-userId fallback now also stringifies the response payload for diagnosability. Replied to and resolved the PR #30 review thread."
         - covers: [I5D12]
           note: "Addressed the sixth Gemini review comment on PR #30 for issue #27: added userId and provider: 'dev-seed' to the subscriptions onConflictDoUpdate set clause in upsertSubscriptionForFixture, ensuring the subscription row is correctly reassigned if a row with the same deterministic dev-seed-{fixture.key} ID was previously associated with a different user. Replied to the PR #30 review thread."
+        - covers: [I5D12]
+          note: "Addressed the seventh Gemini review comment on PR #30 for issue #27: added duration calculation based on plan type in upsertSubscriptionFixture so annual plans use 365 days and monthly plans use 30 days, ensuring the seeded data matches the expected billing shape for both active_pro_monthly and active_pro_annual fixtures. Replied to the PR #30 review thread."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.2.4"
+  release: "1.2.5"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -183,6 +183,8 @@ roadmap:
           note: "Addressed the sixth Gemini review comment on PR #30 for issue #27: added userId and provider: 'dev-seed' to the subscriptions onConflictDoUpdate set clause in upsertSubscriptionForFixture, ensuring the subscription row is correctly reassigned if a row with the same deterministic dev-seed-{fixture.key} ID was previously associated with a different user. Replied to the PR #30 review thread."
         - covers: [I5D12]
           note: "Addressed the seventh Gemini review comment on PR #30 for issue #27: added duration calculation based on plan type in upsertSubscriptionFixture so annual plans use 365 days and monthly plans use 30 days, ensuring the seeded data matches the expected billing shape for both active_pro_monthly and active_pro_annual fixtures. Replied to the PR #30 review thread."
+        - covers: [I5D12]
+          note: "Addressed the eighth, ninth, and tenth Gemini review comments on PR #30 for issue #27: moved duration into SubscriptionSeedShape as explicit periodDays field with MS_PER_DAY constant; kept process.env for flag manipulation due to readonly index signature on SeedGuardEnv; and removed redundant nullish coalescing operators in tiered-auth.ts. Replied to all three PR #30 review threads."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.2.2"
+  release: "1.2.3"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -179,6 +179,8 @@ roadmap:
           note: "Addressed the four Gemini review comments on PR #30 for issue #27: made DEV_TIER_PASSWORD overridable via env; added a DEV_SEED_IN_PROGRESS signal + isDevSeedInProgress helper in src/lib/email/lifecycle.ts that suppresses the outbound Resend call in sendLifecycleEmail while keeping the Better Auth databaseHooks.user.create.after welcome hook flow intact; included priceId: null in the subscriptions onConflictDoUpdate set clause so reruns fully reset the billing shape; and parallelized seedDevUsers via Promise.all(DEV_TIER_KEYS.map(seedEntryForKey)) with unique per-fixture subscription ids keeping the atomic upserts contention-free. Added regression tests for the strict isDevSeedInProgress exact-match contract; replied to and resolved all four PR #30 review threads."
         - covers: [I5D12]
           note: "Addressed the fifth Gemini review comment on PR #30 for issue #27: wrapped auth.api.signUpEmail in a try/catch that rethrows with fixture context and forwards the underlying APIError via the standard Error(..., { cause }) option, preserving the original message and stack for password-complexity, unique-constraint, and transient DB failures; the empty-userId fallback now also stringifies the response payload for diagnosability. Replied to and resolved the PR #30 review thread."
+        - covers: [I5D12]
+          note: "Addressed the sixth Gemini review comment on PR #30 for issue #27: added userId and provider: 'dev-seed' to the subscriptions onConflictDoUpdate set clause in upsertSubscriptionForFixture, ensuring the subscription row is correctly reassigned if a row with the same deterministic dev-seed-{fixture.key} ID was previously associated with a different user. Replied to the PR #30 review thread."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"

--- a/src/lib/dev/seed-dev-users.test.ts
+++ b/src/lib/dev/seed-dev-users.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ResolvedEntitlements,
+	resolveEntitlements,
+} from "../entitlements/entitlements";
+import {
+	DEV_TIER_KEYS,
+	DEV_TIER_USERS,
+	resolveSubscriptionSeedShape,
+} from "./seed-fixtures";
+import { evaluateSeedGuard } from "./seed-guard";
+
+const NODE_ENV_REASON = /NODE_ENV/;
+const ENABLE_DEV_SEED_REASON = /ENABLE_DEV_SEED/;
+const DATABASE_URL_REASON = /DATABASE_URL/;
+
+describe("evaluateSeedGuard", () => {
+	const base = {
+		NODE_ENV: "development",
+		ENABLE_DEV_SEED: "true",
+		DATABASE_URL: "postgres://localhost:5432/dev",
+	};
+
+	it("allows running in local development when explicitly opted in", () => {
+		expect(evaluateSeedGuard(base).allowed).toBe(true);
+	});
+
+	it("allows running under vitest (NODE_ENV=test) when explicitly opted in", () => {
+		expect(evaluateSeedGuard({ ...base, NODE_ENV: "test" }).allowed).toBe(true);
+	});
+
+	it("blocks running in production", () => {
+		const result = evaluateSeedGuard({ ...base, NODE_ENV: "production" });
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toMatch(NODE_ENV_REASON);
+	});
+
+	it("blocks running when VERCEL_ENV is preview or production", () => {
+		expect(evaluateSeedGuard({ ...base, VERCEL_ENV: "preview" }).allowed).toBe(
+			false
+		);
+		expect(
+			evaluateSeedGuard({ ...base, VERCEL_ENV: "production" }).allowed
+		).toBe(false);
+	});
+
+	it("requires ENABLE_DEV_SEED=true", () => {
+		const result = evaluateSeedGuard({ ...base, ENABLE_DEV_SEED: undefined });
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toMatch(ENABLE_DEV_SEED_REASON);
+	});
+
+	it("requires DATABASE_URL so the real resolver path runs", () => {
+		const result = evaluateSeedGuard({ ...base, DATABASE_URL: undefined });
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toMatch(DATABASE_URL_REASON);
+	});
+});
+
+describe("DEV_TIER_USERS fixtures drive the real resolver path", () => {
+	function resolvedForFixture(
+		key: (typeof DEV_TIER_KEYS)[number]
+	): ResolvedEntitlements {
+		const fixture = DEV_TIER_USERS[key];
+		const shape = resolveSubscriptionSeedShape(fixture.subscriptionState);
+		return resolveEntitlements({
+			subscriptionPlanKey: shape?.planKey ?? null,
+			subscriptionStatus: shape?.status ?? null,
+		});
+	}
+
+	it("produces a free tier for the free fixture with no subscription", () => {
+		expect(resolvedForFixture("free").tier).toBe("free");
+	});
+
+	it("produces a pro tier for the pro fixture with an active pro_monthly row", () => {
+		expect(resolvedForFixture("pro").tier).toBe("pro");
+	});
+
+	it("produces an enterprise tier for the enterprise fixture with an active enterprise row", () => {
+		expect(resolvedForFixture("enterprise").tier).toBe("enterprise");
+	});
+
+	it("falls back to free for canceled subscriptions without masking", () => {
+		const resolved = resolvedForFixture("canceled");
+		expect(resolved.tier).toBe("free");
+		expect(resolved.source).toBe("fallback_free");
+	});
+
+	it("falls back to free for past-due subscriptions without masking", () => {
+		const resolved = resolvedForFixture("inactive");
+		expect(resolved.tier).toBe("free");
+		expect(resolved.source).toBe("fallback_free");
+	});
+
+	it("covers the documented tier set", () => {
+		expect([...DEV_TIER_KEYS].sort()).toEqual(
+			["canceled", "enterprise", "free", "inactive", "pro"].sort()
+		);
+	});
+});

--- a/src/lib/dev/seed-dev-users.test.ts
+++ b/src/lib/dev/seed-dev-users.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { isDevSeedInProgress } from "../email/lifecycle";
 import {
 	type ResolvedEntitlements,
 	resolveEntitlements,
@@ -97,5 +98,18 @@ describe("DEV_TIER_USERS fixtures drive the real resolver path", () => {
 		expect([...DEV_TIER_KEYS].sort()).toEqual(
 			["canceled", "enterprise", "free", "inactive", "pro"].sort()
 		);
+	});
+});
+
+describe("isDevSeedInProgress", () => {
+	it("returns true when DEV_SEED_IN_PROGRESS is exactly 'true'", () => {
+		expect(isDevSeedInProgress({ DEV_SEED_IN_PROGRESS: "true" })).toBe(true);
+	});
+
+	it("returns false for any other value or unset", () => {
+		expect(isDevSeedInProgress({})).toBe(false);
+		expect(isDevSeedInProgress({ DEV_SEED_IN_PROGRESS: "TRUE" })).toBe(false);
+		expect(isDevSeedInProgress({ DEV_SEED_IN_PROGRESS: "1" })).toBe(false);
+		expect(isDevSeedInProgress({ DEV_SEED_IN_PROGRESS: "" })).toBe(false);
 	});
 });

--- a/src/lib/dev/seed-dev-users.ts
+++ b/src/lib/dev/seed-dev-users.ts
@@ -103,7 +103,10 @@ async function upsertSubscriptionForFixture(
 	const subscriptionId = `dev-seed-${fixture.key}`;
 	const now = new Date();
 	const periodStart = now;
-	const periodEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+	const durationMs = shape.planKey.includes("annual")
+		? 365 * 24 * 60 * 60 * 1000
+		: 30 * 24 * 60 * 60 * 1000;
+	const periodEnd = new Date(now.getTime() + durationMs);
 	const rawPayload = {
 		source: "dev-seed",
 		fixture: fixture.key,

--- a/src/lib/dev/seed-dev-users.ts
+++ b/src/lib/dev/seed-dev-users.ts
@@ -55,18 +55,32 @@ async function ensureUserForFixture(
 		return { id: existing.id, created: false };
 	}
 
-	const signUp = await auth.api.signUpEmail({
-		body: {
-			email: fixture.email,
-			password: fixture.password,
-			name: fixture.name,
-		},
-	});
+	let signUp: Awaited<ReturnType<typeof auth.api.signUpEmail>>;
+	try {
+		signUp = await auth.api.signUpEmail({
+			body: {
+				email: fixture.email,
+				password: fixture.password,
+				name: fixture.name,
+			},
+		});
+	} catch (cause) {
+		// Better Auth's server API throws APIError on validation/DB failures
+		// (e.g. password complexity, unique constraint, transient DB). Preserve
+		// the original message and stack via `cause` so failed seeds are
+		// diagnosable without digging through logs.
+		const causeMessage = cause instanceof Error ? cause.message : String(cause);
+		throw new Error(
+			`Better Auth signUpEmail failed for ${fixture.email}: ${causeMessage}`,
+			{ cause: cause instanceof Error ? cause : undefined }
+		);
+	}
 
 	const userId = signUp?.user?.id;
 	if (!userId) {
 		throw new Error(
-			`Better Auth signUpEmail did not return a user id for ${fixture.email}`
+			`Better Auth signUpEmail did not return a user id for ${fixture.email}. ` +
+				`Response: ${JSON.stringify(signUp)}`
 		);
 	}
 

--- a/src/lib/dev/seed-dev-users.ts
+++ b/src/lib/dev/seed-dev-users.ts
@@ -103,10 +103,8 @@ async function upsertSubscriptionForFixture(
 	const subscriptionId = `dev-seed-${fixture.key}`;
 	const now = new Date();
 	const periodStart = now;
-	const durationMs = shape.planKey.includes("annual")
-		? 365 * 24 * 60 * 60 * 1000
-		: 30 * 24 * 60 * 60 * 1000;
-	const periodEnd = new Date(now.getTime() + durationMs);
+	const MS_PER_DAY = 24 * 60 * 60 * 1000;
+	const periodEnd = new Date(now.getTime() + shape.periodDays * MS_PER_DAY);
 	const rawPayload = {
 		source: "dev-seed",
 		fixture: fixture.key,

--- a/src/lib/dev/seed-dev-users.ts
+++ b/src/lib/dev/seed-dev-users.ts
@@ -117,6 +117,7 @@ async function upsertSubscriptionForFixture(
 				status: shape.status,
 				planKey: shape.planKey,
 				productId: shape.productId,
+				priceId: null,
 				cancelAtPeriodEnd: shape.cancelAtPeriodEnd,
 				currentPeriodStart: periodStart,
 				currentPeriodEnd: periodEnd,
@@ -128,25 +129,45 @@ async function upsertSubscriptionForFixture(
 	return subscriptionId;
 }
 
+async function seedEntryForKey(key: DevTierKey): Promise<SeedResultEntry> {
+	const fixture = DEV_TIER_USERS[key];
+	const { id: userId, created } = await ensureUserForFixture(fixture);
+	const subscriptionId = await upsertSubscriptionForFixture(userId, fixture);
+	return {
+		created,
+		email: fixture.email,
+		expectedTier: fixture.expectedTier,
+		key,
+		password: fixture.password,
+		subscriptionId,
+		userId,
+	};
+}
+
 export async function seedDevUsers(
 	env: SeedGuardEnv = process.env
 ): Promise<SeedDevUsersResult> {
 	assertSeedGuardAllowed(env);
 
-	const entries: SeedResultEntry[] = [];
-	for (const key of DEV_TIER_KEYS) {
-		const fixture = DEV_TIER_USERS[key];
-		const { id: userId, created } = await ensureUserForFixture(fixture);
-		const subscriptionId = await upsertSubscriptionForFixture(userId, fixture);
-		entries.push({
-			key,
-			userId,
-			email: fixture.email,
-			password: fixture.password,
-			subscriptionId,
-			expectedTier: fixture.expectedTier,
-			created,
-		});
+	// Signal the lifecycle email hook (see `isDevSeedInProgress` in
+	// `@/lib/email/lifecycle`) so Better Auth's `databaseHooks.user.create.after`
+	// welcome-email path short-circuits instead of hitting Resend with dummy
+	// addresses. The real hook still runs end-to-end; only the network call
+	// is suppressed.
+	const previousFlag = process.env.DEV_SEED_IN_PROGRESS;
+	process.env.DEV_SEED_IN_PROGRESS = "true";
+	try {
+		// Fixtures are independent so we can run sign-up + subscription upsert in
+		// parallel. The single-runner seed command cannot contend with itself;
+		// the atomic upsert on `subscriptions.id` keeps the billing shape
+		// deterministic across reruns.
+		const entries = await Promise.all(DEV_TIER_KEYS.map(seedEntryForKey));
+		return { entries };
+	} finally {
+		if (previousFlag === undefined) {
+			Reflect.deleteProperty(process.env, "DEV_SEED_IN_PROGRESS");
+		} else {
+			process.env.DEV_SEED_IN_PROGRESS = previousFlag;
+		}
 	}
-	return { entries };
 }

--- a/src/lib/dev/seed-dev-users.ts
+++ b/src/lib/dev/seed-dev-users.ts
@@ -1,0 +1,152 @@
+/**
+ * Idempotent seed implementation for dev-tier users.
+ *
+ * The implementation runs Better Auth's email/password sign-up for each
+ * fixture and then writes billing-shaped subscription rows so that
+ * `resolveEntitlementsForUserId` returns the expected tier through the
+ * same code path production uses.
+ *
+ * This module is environment-guarded by {@link assertSeedGuardAllowed} and
+ * must never be exported from anywhere that can reach production bundles.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { auth } from "@/lib/auth";
+import { getDb } from "@/lib/db/client";
+import { subscriptions, user } from "@/lib/db/schema";
+import {
+	DEV_TIER_KEYS,
+	DEV_TIER_USERS,
+	type DevTierKey,
+	resolveSubscriptionSeedShape,
+	type SeededUserFixture,
+} from "@/lib/dev/seed-fixtures";
+import {
+	assertSeedGuardAllowed,
+	type SeedGuardEnv,
+} from "@/lib/dev/seed-guard";
+
+export interface SeedResultEntry {
+	created: boolean;
+	email: string;
+	expectedTier: SeededUserFixture["expectedTier"];
+	key: DevTierKey;
+	password: string;
+	subscriptionId: string | null;
+	userId: string;
+}
+
+export interface SeedDevUsersResult {
+	entries: SeedResultEntry[];
+}
+
+async function ensureUserForFixture(
+	fixture: SeededUserFixture
+): Promise<{ id: string; created: boolean }> {
+	const db = getDb();
+	const [existing] = await db
+		.select({ id: user.id })
+		.from(user)
+		.where(eq(user.email, fixture.email))
+		.limit(1);
+
+	if (existing?.id) {
+		return { id: existing.id, created: false };
+	}
+
+	const signUp = await auth.api.signUpEmail({
+		body: {
+			email: fixture.email,
+			password: fixture.password,
+			name: fixture.name,
+		},
+	});
+
+	const userId = signUp?.user?.id;
+	if (!userId) {
+		throw new Error(
+			`Better Auth signUpEmail did not return a user id for ${fixture.email}`
+		);
+	}
+
+	return { id: userId, created: true };
+}
+
+async function upsertSubscriptionForFixture(
+	userId: string,
+	fixture: SeededUserFixture
+): Promise<string | null> {
+	const db = getDb();
+	const shape = resolveSubscriptionSeedShape(fixture.subscriptionState);
+
+	if (!shape) {
+		// Pure Free fixture — ensure no leftover subscription rows mask the state.
+		await db.delete(subscriptions).where(eq(subscriptions.userId, userId));
+		return null;
+	}
+
+	const subscriptionId = `dev-seed-${fixture.key}`;
+	const now = new Date();
+	const periodStart = now;
+	const periodEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+	const rawPayload = {
+		source: "dev-seed",
+		fixture: fixture.key,
+		state: fixture.subscriptionState,
+	};
+
+	await db
+		.insert(subscriptions)
+		.values({
+			id: subscriptionId,
+			userId,
+			provider: "dev-seed",
+			status: shape.status,
+			planKey: shape.planKey,
+			productId: shape.productId,
+			priceId: null,
+			currentPeriodStart: periodStart,
+			currentPeriodEnd: periodEnd,
+			cancelAtPeriodEnd: shape.cancelAtPeriodEnd,
+			rawPayload,
+		})
+		.onConflictDoUpdate({
+			target: subscriptions.id,
+			set: {
+				status: shape.status,
+				planKey: shape.planKey,
+				productId: shape.productId,
+				cancelAtPeriodEnd: shape.cancelAtPeriodEnd,
+				currentPeriodStart: periodStart,
+				currentPeriodEnd: periodEnd,
+				rawPayload,
+				updatedAt: now,
+			},
+		});
+
+	return subscriptionId;
+}
+
+export async function seedDevUsers(
+	env: SeedGuardEnv = process.env
+): Promise<SeedDevUsersResult> {
+	assertSeedGuardAllowed(env);
+
+	const entries: SeedResultEntry[] = [];
+	for (const key of DEV_TIER_KEYS) {
+		const fixture = DEV_TIER_USERS[key];
+		const { id: userId, created } = await ensureUserForFixture(fixture);
+		const subscriptionId = await upsertSubscriptionForFixture(userId, fixture);
+		entries.push({
+			key,
+			userId,
+			email: fixture.email,
+			password: fixture.password,
+			subscriptionId,
+			expectedTier: fixture.expectedTier,
+			created,
+		});
+	}
+	return { entries };
+}

--- a/src/lib/dev/seed-dev-users.ts
+++ b/src/lib/dev/seed-dev-users.ts
@@ -128,6 +128,8 @@ async function upsertSubscriptionForFixture(
 		.onConflictDoUpdate({
 			target: subscriptions.id,
 			set: {
+				userId,
+				provider: "dev-seed",
 				status: shape.status,
 				planKey: shape.planKey,
 				productId: shape.productId,

--- a/src/lib/dev/seed-fixtures.ts
+++ b/src/lib/dev/seed-fixtures.ts
@@ -37,9 +37,12 @@ export interface SeededUserFixture {
 /**
  * Shared password for all dev-tier fixtures. This is only ever used against
  * local or test databases; the seed guard refuses to run in production or
- * preview environments.
+ * preview environments. The default can be overridden with the
+ * `DEV_TIER_PASSWORD` env var so shared dev databases do not rely on a
+ * source-controlled default.
  */
-export const DEV_TIER_PASSWORD = "dev-tier-password-do-not-use-elsewhere";
+export const DEV_TIER_PASSWORD =
+	process.env.DEV_TIER_PASSWORD ?? "dev-tier-password-do-not-use-elsewhere";
 
 const DEV_TIER_DOMAIN = "dev.shipping-api-dojo.local";
 

--- a/src/lib/dev/seed-fixtures.ts
+++ b/src/lib/dev/seed-fixtures.ts
@@ -1,0 +1,163 @@
+/**
+ * Canonical dev-tier seeded user fixtures.
+ *
+ * These fixtures are the single source of truth for the deterministic dev
+ * users that the seed command creates and that Playwright's tiered-auth
+ * smoke suite expects. They are intentionally safe to import from unit
+ * tests, scripts, and browser fixtures because they contain only static
+ * metadata — no runtime side effects.
+ *
+ * A tier fixture pairs a Better Auth email/password account with a
+ * billing-shaped subscription state so the real entitlement resolver path
+ * (manual row + latest subscription) is exercised end-to-end.
+ */
+
+import type { EntitlementTier } from "@/lib/entitlements/entitlements";
+
+export type SeededSubscriptionState =
+	| "none"
+	| "active_pro_monthly"
+	| "active_pro_annual"
+	| "active_enterprise"
+	| "canceled_pro"
+	| "past_due_pro";
+
+export interface SeededUserFixture {
+	email: string;
+	/** Tier the entitlement resolver is expected to report for this fixture. */
+	expectedTier: EntitlementTier;
+	/** Stable key used as the Better Auth user id and subscription row prefix. */
+	key: string;
+	name: string;
+	password: string;
+	/** Billing-shape state the seed command writes into `subscriptions`. */
+	subscriptionState: SeededSubscriptionState;
+}
+
+/**
+ * Shared password for all dev-tier fixtures. This is only ever used against
+ * local or test databases; the seed guard refuses to run in production or
+ * preview environments.
+ */
+export const DEV_TIER_PASSWORD = "dev-tier-password-do-not-use-elsewhere";
+
+const DEV_TIER_DOMAIN = "dev.shipping-api-dojo.local";
+
+export const DEV_TIER_USERS = {
+	free: {
+		key: "dev-free",
+		email: `free@${DEV_TIER_DOMAIN}`,
+		password: DEV_TIER_PASSWORD,
+		name: "Dev Free",
+		expectedTier: "free",
+		subscriptionState: "none",
+	},
+	pro: {
+		key: "dev-pro",
+		email: `pro@${DEV_TIER_DOMAIN}`,
+		password: DEV_TIER_PASSWORD,
+		name: "Dev Pro",
+		expectedTier: "pro",
+		subscriptionState: "active_pro_monthly",
+	},
+	enterprise: {
+		key: "dev-enterprise",
+		email: `enterprise@${DEV_TIER_DOMAIN}`,
+		password: DEV_TIER_PASSWORD,
+		name: "Dev Enterprise",
+		expectedTier: "enterprise",
+		subscriptionState: "active_enterprise",
+	},
+	canceled: {
+		key: "dev-canceled",
+		email: `canceled@${DEV_TIER_DOMAIN}`,
+		password: DEV_TIER_PASSWORD,
+		name: "Dev Canceled",
+		expectedTier: "free",
+		subscriptionState: "canceled_pro",
+	},
+	inactive: {
+		key: "dev-inactive",
+		email: `inactive@${DEV_TIER_DOMAIN}`,
+		password: DEV_TIER_PASSWORD,
+		name: "Dev Inactive",
+		expectedTier: "free",
+		subscriptionState: "past_due_pro",
+	},
+} as const satisfies Record<string, SeededUserFixture>;
+
+export type DevTierKey = keyof typeof DEV_TIER_USERS;
+
+export const DEV_TIER_KEYS: readonly DevTierKey[] = [
+	"free",
+	"pro",
+	"enterprise",
+	"canceled",
+	"inactive",
+];
+
+export function getDevTierFixture(key: DevTierKey): SeededUserFixture {
+	return DEV_TIER_USERS[key];
+}
+
+export interface SubscriptionSeedShape {
+	cancelAtPeriodEnd: boolean;
+	planKey: string;
+	productId: string;
+	status: string;
+}
+
+/**
+ * Resolve the billing-shaped subscription row the seed command should write
+ * for a given fixture state. Returns `null` when no subscription row should
+ * exist (e.g. pure Free users).
+ */
+export function resolveSubscriptionSeedShape(
+	state: SeededSubscriptionState
+): SubscriptionSeedShape | null {
+	switch (state) {
+		case "none":
+			return null;
+		case "active_pro_monthly":
+			return {
+				planKey: "pro_monthly",
+				status: "active",
+				productId: "dev-seed-pro-monthly",
+				cancelAtPeriodEnd: false,
+			};
+		case "active_pro_annual":
+			return {
+				planKey: "pro_annual",
+				status: "active",
+				productId: "dev-seed-pro-annual",
+				cancelAtPeriodEnd: false,
+			};
+		case "active_enterprise":
+			return {
+				planKey: "enterprise",
+				status: "active",
+				productId: "dev-seed-enterprise",
+				cancelAtPeriodEnd: false,
+			};
+		case "canceled_pro":
+			return {
+				planKey: "pro_monthly",
+				status: "canceled",
+				productId: "dev-seed-pro-monthly",
+				cancelAtPeriodEnd: true,
+			};
+		case "past_due_pro":
+			return {
+				planKey: "pro_monthly",
+				status: "past_due",
+				productId: "dev-seed-pro-monthly",
+				cancelAtPeriodEnd: false,
+			};
+		default: {
+			const exhaustive: never = state;
+			throw new Error(
+				`Unhandled seeded subscription state: ${String(exhaustive)}`
+			);
+		}
+	}
+}

--- a/src/lib/dev/seed-fixtures.ts
+++ b/src/lib/dev/seed-fixtures.ts
@@ -105,6 +105,7 @@ export function getDevTierFixture(key: DevTierKey): SeededUserFixture {
 
 export interface SubscriptionSeedShape {
 	cancelAtPeriodEnd: boolean;
+	periodDays: number;
 	planKey: string;
 	productId: string;
 	status: string;
@@ -127,6 +128,7 @@ export function resolveSubscriptionSeedShape(
 				status: "active",
 				productId: "dev-seed-pro-monthly",
 				cancelAtPeriodEnd: false,
+				periodDays: 30,
 			};
 		case "active_pro_annual":
 			return {
@@ -134,6 +136,7 @@ export function resolveSubscriptionSeedShape(
 				status: "active",
 				productId: "dev-seed-pro-annual",
 				cancelAtPeriodEnd: false,
+				periodDays: 365,
 			};
 		case "active_enterprise":
 			return {
@@ -141,6 +144,7 @@ export function resolveSubscriptionSeedShape(
 				status: "active",
 				productId: "dev-seed-enterprise",
 				cancelAtPeriodEnd: false,
+				periodDays: 365,
 			};
 		case "canceled_pro":
 			return {
@@ -148,6 +152,7 @@ export function resolveSubscriptionSeedShape(
 				status: "canceled",
 				productId: "dev-seed-pro-monthly",
 				cancelAtPeriodEnd: true,
+				periodDays: 30,
 			};
 		case "past_due_pro":
 			return {
@@ -155,6 +160,7 @@ export function resolveSubscriptionSeedShape(
 				status: "past_due",
 				productId: "dev-seed-pro-monthly",
 				cancelAtPeriodEnd: false,
+				periodDays: 30,
 			};
 		default: {
 			const exhaustive: never = state;

--- a/src/lib/dev/seed-guard.ts
+++ b/src/lib/dev/seed-guard.ts
@@ -1,0 +1,68 @@
+/**
+ * Environment guard for dev-only seeding.
+ *
+ * The dev-tier seed command creates deterministic Free/Pro/Enterprise/canceled/
+ * inactive users with real Better Auth accounts plus billing-shaped subscription
+ * rows. It must never run against production or preview environments. This
+ * guard is shared between the CLI seed script and its tests so the
+ * gating rules stay in one place.
+ */
+
+export interface SeedGuardEnv {
+	readonly DATABASE_URL?: string | undefined;
+	readonly ENABLE_DEV_SEED?: string | undefined;
+	readonly NODE_ENV?: string | undefined;
+	readonly VERCEL_ENV?: string | undefined;
+	readonly [key: string]: string | undefined;
+}
+
+export interface SeedGuardResult {
+	allowed: boolean;
+	reason?: string;
+}
+
+const ALLOWED_NODE_ENVS = new Set(["development", "test"]);
+const BLOCKED_VERCEL_ENVS = new Set(["production", "preview"]);
+
+export function evaluateSeedGuard(env: SeedGuardEnv): SeedGuardResult {
+	const nodeEnv = env.NODE_ENV ?? "development";
+
+	if (!ALLOWED_NODE_ENVS.has(nodeEnv)) {
+		return {
+			allowed: false,
+			reason: `Dev seeding is only allowed when NODE_ENV is one of [${[...ALLOWED_NODE_ENVS].join(", ")}], received "${nodeEnv}".`,
+		};
+	}
+
+	if (env.VERCEL_ENV && BLOCKED_VERCEL_ENVS.has(env.VERCEL_ENV)) {
+		return {
+			allowed: false,
+			reason: `Dev seeding is blocked when VERCEL_ENV is "${env.VERCEL_ENV}".`,
+		};
+	}
+
+	if (env.ENABLE_DEV_SEED !== "true") {
+		return {
+			allowed: false,
+			reason:
+				'Set ENABLE_DEV_SEED="true" to opt in to the dev-only tiered seed command.',
+		};
+	}
+
+	if (!env.DATABASE_URL) {
+		return {
+			allowed: false,
+			reason:
+				"DATABASE_URL is required for dev seeding so the resolver uses the same code path as production.",
+		};
+	}
+
+	return { allowed: true };
+}
+
+export function assertSeedGuardAllowed(env: SeedGuardEnv): void {
+	const result = evaluateSeedGuard(env);
+	if (!result.allowed) {
+		throw new Error(`[seed-dev-users] ${result.reason}`);
+	}
+}

--- a/src/lib/email/lifecycle.ts
+++ b/src/lib/email/lifecycle.ts
@@ -62,11 +62,25 @@ export function buildLifecycleEmailCopy(
 	}
 }
 
+export function isDevSeedInProgress(
+	env: NodeJS.ProcessEnv = process.env
+): boolean {
+	return env.DEV_SEED_IN_PROGRESS === "true";
+}
+
 async function sendLifecycleEmail(
 	email: string,
 	type: LifecycleEmailType,
 	options?: { planKey?: string | null }
 ) {
+	if (isDevSeedInProgress()) {
+		// The dev-tier seed command opts out of real lifecycle email delivery so
+		// it does not consume Resend quota or bounce against dummy addresses.
+		// The `databaseHooks.user.create.after` hook in `@/lib/auth` still runs
+		// the same code path; only the outbound network call is suppressed.
+		console.warn(`[dev-seed] suppressed ${type} lifecycle email to ${email}`);
+		return;
+	}
 	const env = getAuthEnv();
 	const resend = new Resend(env.RESEND_API_KEY);
 	const copy = buildLifecycleEmailCopy(type, options);

--- a/tests/browser/fixtures/tiered-auth.ts
+++ b/tests/browser/fixtures/tiered-auth.ts
@@ -17,10 +17,7 @@ import { dirname, resolve } from "node:path";
 import type { APIRequestContext, BrowserContext } from "@playwright/test";
 import { request as playwrightRequest } from "@playwright/test";
 
-import {
-	DEV_TIER_USERS,
-	type DevTierKey,
-} from "../../../src/lib/dev/seed-fixtures";
+import { type DevTierKey } from "../../../src/lib/dev/seed-fixtures";
 
 const CREDENTIALS_PATH = resolve(
 	process.cwd(),
@@ -100,11 +97,10 @@ export async function ensureStorageStateForTier(
 		return null;
 	}
 
-	const fixture = DEV_TIER_USERS[options.tier];
 	const resolved: CredentialEntry = {
 		key: options.tier,
-		email: credentials.email ?? fixture.email,
-		password: credentials.password ?? fixture.password,
+		email: credentials.email,
+		password: credentials.password,
 	};
 
 	const statePath = storageStatePathForTier(options.tier);

--- a/tests/browser/fixtures/tiered-auth.ts
+++ b/tests/browser/fixtures/tiered-auth.ts
@@ -1,0 +1,142 @@
+/**
+ * Playwright helpers for dev-tier seeded users.
+ *
+ * The helpers load the credentials file written by `pnpm seed:dev-users`
+ * (`.playwright-auth/credentials.json`) and expose a `storageStateForTier`
+ * function that signs in as the requested tier and returns a Playwright
+ * storage state path. Tests that rely on tier state can consume these
+ * fixtures without duplicating fragile signin steps.
+ *
+ * When the credentials file is missing (e.g. CI without a seeded DB) the
+ * helpers return `null` so callers can skip cleanly instead of failing.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import type { APIRequestContext, BrowserContext } from "@playwright/test";
+import { request as playwrightRequest } from "@playwright/test";
+
+import {
+	DEV_TIER_USERS,
+	type DevTierKey,
+} from "../../../src/lib/dev/seed-fixtures";
+
+const CREDENTIALS_PATH = resolve(
+	process.cwd(),
+	".playwright-auth",
+	"credentials.json"
+);
+
+function storageStatePathForTier(tier: DevTierKey): string {
+	return resolve(process.cwd(), ".playwright-auth", `storage-${tier}.json`);
+}
+
+interface CredentialEntry {
+	email: string;
+	key: DevTierKey;
+	password: string;
+}
+
+interface CredentialsFile {
+	entries: CredentialEntry[];
+}
+
+export function devTierCredentialsAvailable(): boolean {
+	return existsSync(CREDENTIALS_PATH);
+}
+
+function loadCredentials(): CredentialsFile | null {
+	if (!devTierCredentialsAvailable()) {
+		return null;
+	}
+	const raw = readFileSync(CREDENTIALS_PATH, "utf-8");
+	return JSON.parse(raw) as CredentialsFile;
+}
+
+export function getCredentialsForTier(
+	tier: DevTierKey
+): CredentialEntry | null {
+	const file = loadCredentials();
+	if (!file) {
+		return null;
+	}
+	return file.entries.find((entry) => entry.key === tier) ?? null;
+}
+
+async function signInViaApi(
+	request: APIRequestContext,
+	credentials: CredentialEntry
+): Promise<void> {
+	const response = await request.post("/api/auth/sign-in/email", {
+		data: {
+			email: credentials.email,
+			password: credentials.password,
+		},
+	});
+	if (!response.ok()) {
+		const body = await response.text();
+		throw new Error(
+			`sign-in failed for ${credentials.email}: ${response.status()} ${body}`
+		);
+	}
+}
+
+export interface TierStorageStateOptions {
+	baseURL: string;
+	tier: DevTierKey;
+}
+
+/**
+ * Sign in as the requested tier using Better Auth's email/password endpoint
+ * and write a Playwright storage state file that tests can reuse. Returns
+ * the storage state path, or `null` if credentials are missing.
+ */
+export async function ensureStorageStateForTier(
+	options: TierStorageStateOptions
+): Promise<string | null> {
+	const credentials = getCredentialsForTier(options.tier);
+	if (!credentials) {
+		return null;
+	}
+
+	const fixture = DEV_TIER_USERS[options.tier];
+	const resolved: CredentialEntry = {
+		key: options.tier,
+		email: credentials.email ?? fixture.email,
+		password: credentials.password ?? fixture.password,
+	};
+
+	const statePath = storageStatePathForTier(options.tier);
+	const context = await playwrightRequest.newContext({
+		baseURL: options.baseURL,
+	});
+	try {
+		await signInViaApi(context, resolved);
+		const state = await context.storageState();
+		mkdirSync(dirname(statePath), { recursive: true });
+		writeFileSync(statePath, JSON.stringify(state, null, 2), "utf-8");
+	} finally {
+		await context.dispose();
+	}
+	return statePath;
+}
+
+export async function applyTierStorageState(
+	context: BrowserContext,
+	tier: DevTierKey
+): Promise<boolean> {
+	const credentials = getCredentialsForTier(tier);
+	if (!credentials) {
+		return false;
+	}
+	const statePath = storageStatePathForTier(tier);
+	if (!existsSync(statePath)) {
+		return false;
+	}
+	const state = JSON.parse(readFileSync(statePath, "utf-8"));
+	if (state.cookies) {
+		await context.addCookies(state.cookies);
+	}
+	return true;
+}

--- a/tests/browser/tiered-auth.spec.ts
+++ b/tests/browser/tiered-auth.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Tier-gated browser coverage for dev-tier seeded users.
+ *
+ * These tests auto-skip when `.playwright-auth/credentials.json` is missing
+ * (the CI default). Run them locally with:
+ *
+ *   1. populate `.env.local` with DATABASE_URL + ENABLE_DEV_SEED=true
+ *   2. `pnpm seed:dev-users`
+ *   3. `pnpm test:e2e`
+ */
+
+import { expect, test } from "@playwright/test";
+
+import type { DevTierKey } from "../../src/lib/dev/seed-fixtures";
+
+import {
+	devTierCredentialsAvailable,
+	ensureStorageStateForTier,
+} from "./fixtures/tiered-auth";
+
+const HOME_HEADING = /shipping api dojo/i;
+const SETTINGS = /settings/i;
+const CURRENT_ENTITLEMENT_STATE = /current entitlement state/i;
+const UNLOCK_NEW_CHALLENGE_PRO = /unlock new challenge \(pro\)/i;
+const NEW_CHALLENGE = /^new challenge$/i;
+
+const LESSON_PATH =
+	"/lesson/cross-track-2-carrier-capability-matrix-integration-architecture";
+
+const TIER_MATRIX: Array<{
+	tier: DevTierKey;
+	expectInSettings: RegExp;
+	expectUnlockedReroll: boolean;
+}> = [
+	{
+		tier: "free",
+		expectInSettings: /tier:\s*free/i,
+		expectUnlockedReroll: false,
+	},
+	{
+		tier: "pro",
+		expectInSettings: /tier:\s*pro/i,
+		expectUnlockedReroll: true,
+	},
+	{
+		tier: "enterprise",
+		expectInSettings: /tier:\s*enterprise/i,
+		expectUnlockedReroll: true,
+	},
+	{
+		tier: "canceled",
+		expectInSettings: /tier:\s*free/i,
+		expectUnlockedReroll: false,
+	},
+	{
+		tier: "inactive",
+		expectInSettings: /tier:\s*free/i,
+		expectUnlockedReroll: false,
+	},
+];
+
+test.describe("dev-tier seeded auth", () => {
+	test.skip(
+		!devTierCredentialsAvailable(),
+		"Dev-tier credentials not seeded. Run `pnpm seed:dev-users` to enable."
+	);
+
+	for (const entry of TIER_MATRIX) {
+		test(`${entry.tier} tier renders the expected entitlement state`, async ({
+			browser,
+			baseURL,
+		}) => {
+			const statePath = await ensureStorageStateForTier({
+				baseURL: baseURL ?? "http://127.0.0.1:3101",
+				tier: entry.tier,
+			});
+			expect(statePath).not.toBeNull();
+
+			const context = await browser.newContext({
+				storageState: statePath ?? undefined,
+			});
+			const page = await context.newPage();
+			try {
+				await page.goto("/");
+				await expect(
+					page.getByRole("heading", { level: 1, name: HOME_HEADING })
+				).toBeVisible();
+
+				await page.goto("/settings");
+				await expect(
+					page.getByRole("heading", { level: 1, name: SETTINGS })
+				).toBeVisible();
+				await expect(page.getByText(CURRENT_ENTITLEMENT_STATE)).toBeVisible();
+				await expect(
+					page.getByText(entry.expectInSettings).first()
+				).toBeVisible();
+
+				await page.goto(LESSON_PATH);
+				if (entry.expectUnlockedReroll) {
+					await expect(
+						page.getByRole("button", { name: NEW_CHALLENGE })
+					).toBeVisible();
+				} else {
+					await expect(
+						page.getByRole("link", { name: UNLOCK_NEW_CHALLENGE_PRO })
+					).toBeVisible();
+				}
+			} finally {
+				await context.close();
+			}
+		});
+	}
+});
+
+test("anonymous baseline still sees locked premium rerolls even with tier seeds present", async ({
+	page,
+}) => {
+	await page.goto(LESSON_PATH);
+	await expect(
+		page.getByRole("link", { name: UNLOCK_NEW_CHALLENGE_PRO })
+	).toBeVisible();
+});


### PR DESCRIPTION
Implement issue #27 (I5D12) to unblock rigorous testing of the paid-tier flows planned under #21. A guarded `pnpm seed:dev-users` command creates deterministic Free/Pro/Enterprise/canceled/past-due users through Better Auth sign-up and writes billing-shaped subscription rows so the real entitlement resolver path decides the tier. Playwright storage-state helpers and a tier-gated smoke spec auto-skip when credentials are not seeded, keeping CI without a database green. Unit coverage asserts every guard branch and the fixture-to-resolver mapping for every state, and canceled/past-due fixtures deliberately fall back to Free without masking via manual entitlements. Release bumped to 1.2.0.

Refs v1.2.0 #27 I5D12