### PR TITLE
docs(v2): add final production readiness issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,33 @@ The current public build includes:
 - **Wiki** reference content for shipping/API concepts
 - **Directory** curated links to specs, tools, and carrier resources
 - **Anonymous local progress** stored in the browser today
+- **Signed-in server-backed progress** through Better Auth and Neon/Drizzle
 - **Tier-aware gating** for premium challenge depth while keeping public educational pages crawlable
 - **Server-owned practice seeds** for signed-in randomized practice flows
+- **Creem webhook-based entitlement sync** for Pro subscription state
+- **Resend transactional email plumbing** for auth and lifecycle messages
+- **Sentry-ready observability** that stays off until DSNs are configured
 
-## V2 Direction
+## V2 Completion State
 
-The active v2 plan is tracked in [`specs/current-changes`](specs/current-changes) and centers on:
+The v2 platform work is implemented and tracked in
+[`specs/current-changes`](specs/current-changes):
 
 - 20 lessons, 20 drill families, and 20 scenario families
 - deterministic content families and seeded randomization
 - signed-in server-backed progress with Better Auth + Neon/Drizzle
-- hosted access tiers: anonymous sample -> signed-in free -> Pro -> Enterprise
-- Creem billing, Resend transactional email, and `shipping.apidojo.app` as the target production domain under the `apidojo.app` umbrella
+- hosted access tiers: anonymous sample -> signed-in free -> Pro, with Enterprise reserved for inquiry-only future work
+- Creem billing webhooks, Resend transactional email, and `shipping.apidojo.app` as the target production domain under the `apidojo.app` umbrella
 - stronger SEO-first knowledge architecture around lessons, wiki, and directory surfaces
 
-## Hosted Access Matrix (Current Slice)
+The remaining v2 launch-readiness gap is tracked in
+[#36](https://github.com/BallLightningAB/shipping-api-dojo/issues/36): a
+public plans/product page, visible sign-in/account entry points, Creem
+Storefront CTAs for Pro monthly and annual products, explicit Enterprise
+inquiry-only messaging, and a target-environment acceptance pass for auth,
+billing, email, observability, database, and browser flows.
+
+## Hosted Access Matrix
 
 - **Free**
   - Public lessons, wiki, and directory
@@ -37,12 +49,25 @@ The active v2 plan is tracked in [`specs/current-changes`](specs/current-changes
   - All Free surfaces
   - Premium lesson and arena challenge rerolls
   - Advanced review-depth scenario access
-  - Certificate-basic capability reserved for certificate implementation
-- **Enterprise**
-  - All Pro surfaces
-  - Branded certificate capability, team reporting, and custom premium-pack capability
+  - Available as monthly and annual Pro products in Creem
+- **Enterprise inquiries**
+  - Not implemented as a checkout product today
+  - No Team or Enterprise plan is currently live
+  - Support handles Enterprise, team, procurement, or custom-access questions manually
 
 The current implementation gates premium actions and depth (for example rerolls and advanced arena ladders) instead of hiding public SEO-critical pages.
+
+### Creem Pro Products
+
+The two configured product IDs are both Pro products:
+
+- Monthly Pro: `CREEM_PRO_MONTHLY_PRODUCT_ID=prod_3jDZfwYMV4z7s0yyzLMGtp`
+- Annual Pro: `CREEM_PRO_ANNUAL_PRODUCT_ID=prod_2UKovfLiNB4uUAdlQrN2TD`
+
+Storefront URLs are intentionally separate runtime configuration from product
+IDs. Product IDs drive webhook plan resolution; public CTAs should point to
+Creem's customer-facing Storefront URLs once issue `#36` implements the public
+plans flow.
 
 ## Practice Seed Security
 
@@ -95,16 +120,14 @@ The generator reads `src/content/families` (lessons), `src/content/wiki` (concep
 - **TanStack Start** (React 19, file-based routing, SSR)
 - **Tailwind CSS v4** + shadcn/ui + Lucide icons
 - **@tanstack/react-store** for anonymous/local progress state
+- **Better Auth** for hosted accounts and sessions
+- **Neon Postgres** + **Drizzle ORM** for durable progress, auth-adjacent state, billing events, and entitlements
+- **Creem** webhook handling for subscription and entitlement sync
+- **Resend** for transactional email rendering, sending, and webhook ingestion
+- **Sentry** SDK wrappers for opt-in hosted error reporting
 - **Zod** for runtime validation
 - **Biome** + Ultracite for formatting/linting
 - **Vite** for bundling, deployed to **Vercel**
-
-### Planned v2 additions
-
-- **Better Auth** for hosted accounts and sessions
-- **Neon Postgres** + **Drizzle ORM** for durable progress and entitlements
-- **Creem** for subscriptions and billing
-- **Resend** for transactional email
 
 ## Getting Started
 
@@ -162,6 +185,26 @@ pnpm exec playwright install chromium
 ```
 
 The browser suite is intentionally narrow: it smoke-tests the home page, the learning hubs, a representative lesson route, the arena, wiki content, and the directory. Keep broader logic coverage in Vitest and grow the browser suite only when a route-level regression risk justifies it.
+
+### Production Readiness Acceptance
+
+Before enabling paid production access, issue
+[#36](https://github.com/BallLightningAB/shipping-api-dojo/issues/36) requires
+one targeted acceptance pass beyond the normal unit/lint/build checks:
+
+- Run `pnpm test:checkpoint`.
+- Seed dev users and run `pnpm test:e2e` with `.playwright-auth/credentials.json`
+  present so tiered auth states execute instead of skipping.
+- Verify sign-up, sign-in, sign-out, session persistence, account settings, and
+  account export on the target deployment.
+- Verify Neon schema/migration state against the target database.
+- Replay or send Creem test events for active, canceled, and past-due Pro
+  subscriptions and confirm entitlement transitions.
+- Verify monthly and annual Pro Storefront CTAs from the deployed site.
+- Verify Resend transactional send plus webhook delivery.
+- Verify a Sentry test event with DSN configured and privacy scrubbing intact.
+- Smoke test the deployed home, plans, learning hubs, representative lesson,
+  arena, wiki, directory, privacy, cookies, and settings routes.
 
 ## Domains
 

--- a/specs/archived/completed/issue-13-fresh-thread-prompt.md
+++ b/specs/archived/completed/issue-13-fresh-thread-prompt.md
@@ -1,0 +1,66 @@
+# Fresh-Thread Prompt — Issue #13 Mobile Readiness and Native App Strategy
+
+Use this prompt to start a brand-new conversation. Run in a dedicated worktree so it can execute in parallel with issue #15.
+
+## Worktree setup (run once before starting the new thread)
+
+```bash
+# From the main repo at c:/Users/nicol/CascadeProjects/BallLightning/shipping-api-dojo
+git fetch origin
+git worktree add ../shipping-api-dojo-issue-13 -b codex/issue-13-mobile-readiness origin/main
+```
+
+Open the new worktree as the workspace for the fresh thread:
+`c:/Users/nicol/CascadeProjects/BallLightning/shipping-api-dojo-issue-13`
+
+## Prompt to paste into the fresh thread
+
+> Implement issue [#13 Mobile Readiness and Native App Strategy](https://github.com/BallLightningAB/shipping-api-dojo/issues/13) on branch `codex/issue-13-mobile-readiness` in this worktree.
+>
+> **This is a strategy + light-touch refactor issue, not a feature build.** No native app code is shipped here. The deliverables are:
+>
+> - a written strategy document
+> - small, surgical refactors that protect platform-neutral domain boundaries in the existing web codebase
+>
+> **Context to read first (in full, up to 1000 lines per file):**
+>
+> - `specs/memory-bank/active-context.yaml`
+> - `specs/memory-bank/memory-bank-usage.yaml`
+> - `specs/memory-bank/CHANGELOG.yaml`
+> - `specs/current-changes/issue-13-mobile-readiness-outline.md`
+> - `specs/shipping-api-dojo-pdd.yaml`
+> - Domain-shaped modules: `src/lib/randomization.ts`, `src/lib/practice/*`, `src/lib/progress/*`, `src/lib/entitlements/*`, `src/content/*`, `src/lib/auth/*`, `src/lib/billing/*`.
+>
+> Also apply the workflow at `%USERPROFILE%\.codeium\windsurf\global_workflows\initiate-memorybank.md` and check for relevant skills.
+>
+> **Goal:** Define how Shipping API Dojo can become a future native product without forcing premature complexity into the current web-first implementation. Protect platform-neutral domain logic so a future React Native (Expo) client can reuse it.
+>
+> **Deliverables (`I13D1`–`I13D5`):**
+>
+> 1. **`I13D1` — review v2 architecture for mobile blockers.** Audit the modules listed above and produce a written list of:
+>    - functions that already touch browser-only APIs (`window`, `document`, `localStorage`, `IntersectionObserver`, etc.) and whether each one belongs in the domain layer or the route layer.
+>    - functions that depend on TanStack Router/Start internals that a native client could not call.
+>    - any place where IDs, certificate URLs, or premium capability names are derived from URL state instead of stable domain values.
+> 2. **`I13D2` — platform-neutral boundaries.** Where the audit finds leakage of browser-only code into shared domain modules, perform small, surgical refactors to extract the domain logic into platform-neutral helpers (no `window`, no React, no router imports). Keep web behavior identical; cover with unit tests. **Do not** introduce a separate package or workspace — keep everything inside `src/` for now.
+> 3. **`I13D3` — likely native stack and app strategy.** Document the recommendation (default: React Native + Expo) with concrete justification: how much TS / domain code can realistically be shared, how routing differs, what stays web-only. Cover both "thin native shell that reuses the API" and "fully native client" options.
+> 4. **`I13D4` — future auth/session approach for native clients.** Document how Better Auth would be configured for native (token storage, refresh strategy, deep-link callback URLs, biometric gate, device-bound sessions). No code changes — strategy only.
+> 5. **`I13D5` — API, deep-linking, offline, and app-store follow-up.** Document the future contracts: which endpoints must be public-API-shaped, deep-link URL scheme, offline cache + sync conflict rules, push-notification surface, and app-store billing vs hosted-web billing strategy.
+>
+> Output the strategy in a new `specs/current-changes/issue-13-mobile-readiness-plan.md` (long-form plan; keep the existing outline as the high-level source of truth).
+>
+> **Out of scope:**
+>
+> - shipping any actual native app code or React Native dependencies
+> - introducing pnpm workspaces, Turbo, Nx, or any monorepo tooling
+> - changing user-visible web behavior
+> - issue #15 wiki expansion work
+>
+> **Validation:** `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test --run`. Any refactor must keep the existing test suite green and add tests for the extracted domain helpers.
+>
+> **Workflow expectations:**
+>
+> - Use the `tanstack-start-best-practices` and `tanstack-router-best-practices` skills when reasoning about which logic belongs in route layers vs domain layers.
+> - Use the `Context7 MCP` for current TanStack Start / Router / Query / Better Auth docs before introducing new APIs.
+> - Keep edits incremental and commit-prep only at the end via the `commitprocess` workflow; bump `meta.release` to `1.3.3` (patch — strategy + small refactor, no user-visible change) and add a CHANGELOG entry.
+>
+> When the strategy doc + refactors are complete and validation is green, prepare a commit + PR description and stop. Do not auto-merge. Do not start issue #15 from this thread.

--- a/specs/archived/completed/issue-13-mobile-readiness-outline.md
+++ b/specs/archived/completed/issue-13-mobile-readiness-outline.md
@@ -1,0 +1,58 @@
+# Mobile Readiness and Native App Strategy Plan
+
+Date: 2026-03-17
+Issue: [#13](https://github.com/BallLightningAB/shipping-api-dojo/issues/13)
+Branch: `codex/issue-13-mobile-readiness`
+Scope: Follow-on strategy only after the web v2 work is complete.
+
+## Rough Estimate
+
+- Dev: 6h
+- Test/validation: 3h
+
+## Goal
+
+Define how Shipping API Dojo can become a future native product without forcing premature complexity into the current web-first implementation.
+
+## Deliverable Mapping
+
+- `I13D1`: review the v2 architecture for mobile blockers
+- `I13D2`: define the platform-neutral boundaries required for a future native client
+- `I13D3`: decide the likely native stack and app strategy
+- `I13D4`: define the future auth/session approach for native clients
+- `I13D5`: define the API, deep-linking, offline, and app-store follow-up work
+
+## Current Recommendation
+
+- finish the web v2 first
+- keep the current implementation web-first
+- protect platform-neutral domain logic now so native can reuse it later
+- treat React Native with Expo as the likely future mobile direction unless a later constraint changes that
+
+## Mobile-Neutral Requirements For Web V2
+
+- content family definitions stay independent of React route components
+- scoring and run-generation logic stay independent of browser-only APIs
+- progress, entitlements, certificates, and challenge runs are exposed through backend contracts that a native client can call later
+- local browser storage stays a client-side cache or anonymous-only mechanism, not the long-term canonical model
+- IDs, certificate URLs, and premium capability names stay stable across surfaces
+- web-only SEO concerns such as canonicals, sitemaps, and route metadata stay at the route layer rather than polluting shared domain logic
+
+## Topics To Resolve Later
+
+- native auth flow with Better Auth
+- offline caching and sync conflict rules
+- push notifications and reminder logic
+- deep-linking into lessons, challenges, and certificates
+- app-store billing versus hosted-web billing strategy
+- how much code can actually be shared between web and native clients
+
+## Acceptance Criteria
+
+- the follow-up issue clearly captures the mobile path without inflating current scope
+- the web v2 plans preserve platform-neutral boundaries where that adds real future leverage
+
+## Validation And Iteration
+
+- validate the mobile-readiness recommendations against the actual `#7`, `#11`, `#8`, and `#9` implementation plans
+- flag any web-only assumption that would force a future native rewrite of core learning, progress, or entitlement logic

--- a/specs/archived/completed/issue-15-fresh-thread-prompt.md
+++ b/specs/archived/completed/issue-15-fresh-thread-prompt.md
@@ -1,0 +1,52 @@
+# Fresh-Thread Prompt — Issue #15 Wiki Expansion
+
+Use this prompt to start a brand-new conversation. Run in a dedicated worktree so it can execute in parallel with issue #13.
+
+## Worktree setup (run once before starting the new thread)
+
+```bash
+# From the main repo at c:/Users/nicol/CascadeProjects/BallLightning/shipping-api-dojo
+git fetch origin
+git worktree add ../shipping-api-dojo-issue-15 -b codex/issue-15-wiki-expansion origin/main
+```
+
+Open the new worktree as the workspace for the fresh thread:
+`c:/Users/nicol/CascadeProjects/BallLightning/shipping-api-dojo-issue-15`
+
+## Prompt to paste into the fresh thread
+
+> Implement issue [#15 Wiki Expansion](https://github.com/BallLightningAB/shipping-api-dojo/issues/15) on branch `codex/issue-15-wiki-expansion` in this worktree.
+>
+> **Context to read first (in full, up to 1000 lines per file):**
+>
+> - `specs/memory-bank/active-context.yaml`
+> - `specs/memory-bank/memory-bank-usage.yaml`
+> - `specs/memory-bank/CHANGELOG.yaml`
+> - `specs/current-changes/issue-15-wiki-expansion-outline.md`
+> - `specs/shipping-api-dojo-pdd.yaml`
+> - The existing wiki/directory surfaces: `src/content/directory.ts`, `src/content/families.ts`, and any vendor pages already scaffolded by issue #9.
+>
+> Also apply the workflow at `%USERPROFILE%\.codeium\windsurf\global_workflows\initiate-memorybank.md` and check for relevant skills (especially `programmatic-seo`, `seo-audit`, `schema-markup`, and `tanstack-router-best-practices`).
+>
+> **Goal:** Expand the wiki from curriculum-supporting pages into a durable carrier-reference library organized by vendor, business unit / product line, country / region, and protocol / documentation surface — without duplicating issue #9's curriculum-only scope.
+>
+> **Deliverables (`I15D1`–`I15D5`):**
+>
+> 1. **Taxonomy and URL conventions** — define the long-term wiki taxonomy (vendor → business unit → region → protocol) and a stable URL convention that survives future reorganization. Document it in a new `specs/current-changes/issue-15-wiki-expansion-plan.md` (the long-form plan; keep the existing outline as the high-level source of truth).
+> 2. **Highest-value carrier surfaces** — identify and prioritize the first 8–12 carrier surfaces to document (DHL Express vs DHL eCommerce vs DHL Parcel, UPS, FedEx Express vs FedEx Ground, USPS, Royal Mail, La Poste / Colissimo, Australia Post, Japan Post, regional consolidators). Justify the ordering against issue #5 acquisition value.
+> 3. **Precise vendor / business-unit / region / protocol pages** — implement the new wiki pages following the taxonomy. Avoid generic "DHL" summary pages; each page must be specific (business unit, country, protocol family). Use the content-family direction established in issue #5; do not bolt onto issue #9's drill-supporting pages.
+> 4. **Directory expansion** — extend the directory with official docs URLs, deprecation notices, sandbox/test-mode notes, and protocol-specific tooling (SOAP WSDL, REST OpenAPI, EDI X12 / EDIFACT, GraphQL where applicable). Keep the schema in `src/content/directory.ts` source-of-truth and add tests for any new validators.
+> 5. **SEO and internal-linking rules** — define canonical, sitemap, internal-link, and `schema.org` rules so the expanded wiki stays indexable and useful. Apply the `schema-markup` skill for FAQ / Article / BreadcrumbList JSON-LD on the new pages.
+>
+> **Out of scope:** mobile native readiness (issue #13), additional curriculum content beyond what already exists, paywall changes, randomization changes.
+>
+> **Validation:** `pnpm format`, `pnpm lint`, `pnpm typecheck`, `pnpm test --run`, `pnpm build`. Add regression tests for any new content schema, SEO meta, and structured-data helpers.
+>
+> **Workflow expectations:**
+>
+> - Use `tanstack-start-best-practices`, `tanstack-router-best-practices`, `tanstack-query-best-practices`, and `tanstack-integration-best-practices` skills for any new routes or loaders.
+> - Use the `Context7 MCP` for current TanStack Start / Router / Query docs before introducing new APIs.
+> - Use the `programmatic-seo` and `schema-markup` skills for the directory and wiki page templates.
+> - Keep edits incremental, commit-prep only at the end via the `commitprocess` workflow; bump `meta.release` to `1.4.0` (minor — new feature surface) and add a CHANGELOG entry.
+>
+> When the implementation is complete and validation is green, prepare a commit + PR description and stop. Do not auto-merge. Do not start issue #13 from this thread.

--- a/specs/archived/completed/issue-15-wiki-expansion-outline.md
+++ b/specs/archived/completed/issue-15-wiki-expansion-outline.md
@@ -1,0 +1,29 @@
+# Issue 15 Wiki Expansion Outline
+
+Date: 2026-04-12
+Issue: [#15](https://github.com/BallLightningAB/shipping-api-dojo/issues/15)
+Branch: `codex/issue-15-wiki-expansion`
+Scope: In-scope issue `#5` web-v2 knowledge-surface expansion after issue `#9`.
+
+## Goal
+
+Expand the Shipping API Dojo wiki from curriculum-supporting support pages into a durable reference library organized by:
+
+- vendor
+- business unit or product line
+- country or region
+- protocol or documentation surface
+
+## Why This Is Separate From Issue 9
+
+- Issue `#9` only ships the wiki and directory additions required by the 20/20/20 curriculum.
+- Vendor documentation expansion is broader than the curriculum and must not bloat the migration issue, but it remains part of the issue `#5` v2 umbrella.
+- DHL, UPS, FedEx, USPS, and similar vendors should not be treated as single unified API surfaces when the real behavior varies by business unit, country, or protocol family.
+
+## Outline
+
+1. Define the long-term wiki taxonomy and URL conventions.
+2. Identify the highest-value carrier surfaces to document first.
+3. Add precise vendor/business-unit/region/protocol pages instead of generic vendor summaries.
+4. Expand the directory with official docs, deprecation notices, and protocol-specific tooling.
+5. Define SEO and internal-linking rules so the expanded wiki remains useful and indexable.

--- a/specs/current-changes/issue-5-final-production-readiness-plan.md
+++ b/specs/current-changes/issue-5-final-production-readiness-plan.md
@@ -1,0 +1,166 @@
+# Issue 5 Final Production Readiness Plan
+
+Date: 2026-04-27
+Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
+Issue: [#36](https://github.com/BallLightningAB/shipping-api-dojo/issues/36)
+Branch: `codex/issue-5-production-readiness`
+Release: `1.4.1.6` (documentation and final readiness planning)
+
+## Goal
+
+Close the remaining gap between the implemented web-v2 platform and a
+production-ready paid product. The core v2 implementation is complete, but the
+public website still needs clear product, plan, sign-in, and purchase surfaces
+before Creem payment activation can be approved and before Shipping API Dojo is
+treated as commercially ready.
+
+This issue is the final `#5` sub-issue. It does not reopen the completed
+curriculum, wiki, auth foundation, entitlement, seed-security, observability, or
+compliance work. It verifies and exposes those systems as a coherent product.
+
+## Current Gap
+
+- Pro product IDs exist and are the only paid product IDs currently in scope:
+  - `CREEM_PRO_MONTHLY_PRODUCT_ID=prod_3jDZfwYMV4z7s0yyzLMGtp`
+  - `CREEM_PRO_ANNUAL_PRODUCT_ID=prod_2UKovfLiNB4uUAdlQrN2TD`
+- There is no Team or Enterprise plan currently implemented.
+- The site describes plan capabilities mainly inside `/settings`, which is a
+  noindex account/settings page and not an adequate public product surface.
+- The header does not expose a public sign-in action or a public plans/pricing
+  page.
+- Upgrade links in lessons and arena currently point to `/settings#paid-access`
+  rather than a public product/pricing page or Creem Storefront path.
+- Enterprise copy exists in the internal capability matrix, but the product
+  needs to clearly state that Enterprise is not available yet and should be
+  handled by support inquiry only.
+- Production external integrations still need an explicit acceptance pass
+  against the target deployment and provider dashboards.
+
+## Deliverables
+
+### I5D14.1 Public product and pricing page
+
+Create a public, crawlable product/plans page, likely `/pricing` or `/plans`,
+that makes the paid product clear enough for Creem payment activation review.
+
+Required content:
+
+- What Shipping API Dojo is.
+- What Free includes.
+- What Pro includes.
+- Monthly and annual Pro purchase CTAs.
+- Clear statement that the two Creem product IDs are both Pro products.
+- Clear statement that Team and Enterprise are not implemented yet.
+- Contact-support CTA for Enterprise, teams, procurement, custom access, or
+  support questions.
+- Links back into the concrete product surfaces: lessons, arena, wiki, and
+  directory.
+- Privacy/cookie/support links reachable from the page.
+
+### I5D14.2 Creem Storefront direction
+
+Add the runtime configuration and UI needed to direct customers to the Creem
+Storefront for Pro.
+
+Acceptance criteria:
+
+- Configure monthly and annual Pro storefront URLs without hard-coding secrets.
+- Keep product IDs separate from storefront URLs so webhooks still resolve by
+  product ID while public CTAs use Creem's customer-facing purchase URLs.
+- Add prominent Pro monthly and Pro annual CTAs on the public plans page.
+- Do not expose any Enterprise checkout CTA until an Enterprise product exists.
+- If storefront URLs are missing, render a support-contact fallback instead of
+  a broken purchase link.
+
+### I5D14.3 Sign-in and navigation affordances
+
+Make account and plan entry points visible across the site.
+
+Acceptance criteria:
+
+- Header includes a visible sign-in/account action.
+- Header and footer include a public plans/pricing link.
+- Public paid-feature lock states link to the public plans page instead of
+  `/settings#paid-access`.
+- Settings keeps entitlement/status details, but no longer acts as the primary
+  sales page.
+- Anonymous, Free, and paid users all see coherent CTA copy for their state.
+
+### I5D14.4 Paid feature direction from product surfaces
+
+Update the learning surfaces so users understand what paid access unlocks.
+
+Acceptance criteria:
+
+- Lesson premium reroll lock copy points to Pro and links to the public plans
+  page.
+- Arena advanced-depth lock copy points to Pro and links to the public plans
+  page.
+- Wiki, directory, and learning hubs include lightweight, non-intrusive links
+  to plans where appropriate.
+- Public SEO-critical educational content remains crawlable and not hidden
+  behind auth or checkout.
+
+### I5D14.5 External integration acceptance tests
+
+Run a targeted launch-readiness acceptance pass against preview or production.
+
+Required checks:
+
+- `pnpm test:checkpoint`.
+- Seed dev users and run `pnpm test:e2e` with tiered auth credentials present
+  so Free, Pro, Enterprise-shaped, canceled, and past-due states actually run
+  instead of skipping.
+- Production or preview smoke test for sign-up, sign-in, sign-out, session
+  persistence, account settings, and account export.
+- Neon migration/schema verification against the target database.
+- Creem webhook replay or test events for active, canceled, and past-due Pro
+  subscriptions, verifying entitlement transitions.
+- Creem Storefront monthly and annual Pro CTA verification from the deployed
+  site.
+- Resend transactional email send plus webhook delivery verification.
+- Sentry DSN test event verification with privacy scrubbing confirmed.
+- Browser smoke against the deployed target for home, plans, learning hubs,
+  representative lesson, arena, wiki, directory, privacy, cookies, and settings.
+- `pnpm audit --json` remains zero-advisory or has a documented exception.
+
+### I5D14.6 Documentation and launch state cleanup
+
+Keep the repo documents aligned with the final v2 state.
+
+Acceptance criteria:
+
+- README describes Better Auth, Neon/Drizzle, Creem, Resend, and Sentry as
+  implemented infrastructure, not planned additions.
+- README makes clear that Pro is the only storefront-backed paid plan today.
+- README makes clear that Enterprise is an inquiry/future plan, not an
+  implemented checkout product.
+- `specs/memory-bank/active-context.yaml` marks completed v2 sub-issues
+  correctly and leaves only this final readiness issue open under `#5`.
+- `specs/current-changes/issue-5-joint-plan.md` includes this final readiness
+  sub-issue and explains that `#5` closes after it.
+
+## Non-goals
+
+- Do not implement Team or Enterprise checkout.
+- Do not implement certificates, team reporting, or custom packs.
+- Do not add analytics or marketing pixels.
+- Do not hide the public lessons, wiki, or directory behind auth.
+- Do not move the product to a new domain as part of this issue unless the
+  deployment already targets `shipping.apidojo.app`.
+
+## Exit Criteria
+
+This issue is complete when:
+
+- The public site clearly describes Free and Pro.
+- Pro monthly and annual CTAs direct customers to Creem Storefront or a safe
+  support fallback when configuration is missing.
+- Enterprise is clearly marked as not yet implemented and inquiry-only.
+- Sign-in/account and plans navigation are visible from the main site.
+- Product surfaces direct users to paid plans where paid capabilities are
+  encountered.
+- External integrations have been verified against the target environment.
+- README and memory-bank state no longer describe completed v2 systems as
+  planned or in-progress.
+- Parent issue `#5` can be closed as completed.

--- a/specs/current-changes/issue-5-joint-plan.md
+++ b/specs/current-changes/issue-5-joint-plan.md
@@ -1,8 +1,8 @@
 # Issue 5 Joint Plan
 
-Date: 2026-04-12
+Date: 2026-04-27
 Parent issue: [#5](https://github.com/BallLightningAB/shipping-api-dojo/issues/5)
-Scope: Coordination plan for the full Shipping API Dojo web-v2 program anchored by `#5`, with core execution across `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, `#27`, and `#28`.
+Scope: Coordination plan for the full Shipping API Dojo web-v2 program anchored by `#5`, with core execution across `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, `#27`, `#28`, and the final production-readiness issue `#36`.
 
 ## Goal
 
@@ -19,6 +19,7 @@ Deliver issue `#5` through a strict sequence that separates:
 - production-grade hosted error reporting
 - development-only tiered auth and billing-state fixtures for browser validation
 - server-authoritative seed security for certificate-safe randomized practice
+- final public product, plans, sign-in, Creem Storefront, and production integration acceptance surfaces
 
 Issue `#5` provides the global instructions and guardrails for the whole web-v2 implementation chain. Subplans should not reinterpret its product boundary, testing standard, or SEO posture independently.
 
@@ -28,6 +29,8 @@ Issue `#5` provides the global instructions and guardrails for the whole web-v2 
 - The `apidojo.app` purchase and subdomain/DNS setup are required work, not a launch footnote.
 - API Trainer gets a fresh dedicated Resend account and sending domain.
 - Hosted access follows `anonymous sample -> signed-in free -> Pro -> Enterprise`.
+- Pro is the only storefront-backed paid plan currently in scope, using the monthly product ID `prod_3jDZfwYMV4z7s0yyzLMGtp` and annual product ID `prod_2UKovfLiNB4uUAdlQrN2TD`.
+- Team and Enterprise checkout are not implemented yet; Enterprise must remain an inquiry/support path until a real product and entitlement model exist.
 - Local-only progress remains anonymous-only.
 - Signed-in progress becomes server-backed.
 - The public repo stays open core.
@@ -42,6 +45,7 @@ Issue `#5` provides the global instructions and guardrails for the whole web-v2 
 - Hosted v2 observability belongs in `#26`; issue `#21` may add a lightweight wrapper but full Sentry setup should stay separate.
 - Dev-only tiered auth and billing-state fixtures belong in `#27` so Free/Pro/Enterprise/canceled states can be exercised without polluting production data.
 - Seed-security hardening belongs in `#28`; deterministic randomization was proven in `#8/#9`, but URL-visible seeds must be removed before certificate-bearing or competitive paid practice flows launch.
+- Final production readiness belongs in `#36`; public plan/product copy, storefront CTAs, sign-in/account navigation, and deployed external integration acceptance must complete before `#5` closes.
 - EDI should be treated as a sibling-product strategy issue in `#16`, not as a third track inside Shipping API Dojo and not as a `#5` blocker.
 
 ## Current Execution Notes
@@ -49,8 +53,8 @@ Issue `#5` provides the global instructions and guardrails for the whole web-v2 
 - The public product identity is now `Shipping API Dojo`, with `API Dojo` treated as the umbrella brand for future sibling products.
 - Public SEO copy should prefer keyword phrases like `shipping API training`, `carrier APIs`, and `carrier integrations` instead of reviving the old `API Trainer` product label.
 - Issues `#10`, `#12`, `#19`, and `#20` are complete, but `#10` was outline-only and does not mean paid tiers/content gating are implemented.
-- Issue `#21` is complete after PR `#25`; issue `#5` remains open until the remaining in-scope v2 items such as `#15`, `#26`, `#27`, and `#28` complete or are explicitly deferred.
-- Issues `#26`, `#27`, and `#28` are now in-scope v2 support sub-issues under `#5`.
+- Issues `#15`, `#21`, `#26`, `#27`, and `#28` are complete. Issue `#5` remains open only for final production readiness in `#36`.
+- Issue `#36` is the final in-scope v2 support sub-issue under `#5`.
 - Issues `#13` and `#16` are still useful strategy work, but they are not blockers for `#5`.
 - During future implementation issues, keep GitHub, the issue-local plan artifact, and `active-context.yaml` aligned so resumability does not depend on terminal history.
 
@@ -72,6 +76,7 @@ Additional v2 support issues:
 - `#26` is an in-scope v2 sub-issue for Sentry Free-tier observability on hosted error paths.
 - `#27` is an in-scope v2 sub-issue for dev-only tiered seed users and Playwright auth states.
 - `#28` is an in-scope critical v2 sub-issue for server-authoritative seed security before certificates or challenge-validity claims.
+- `#36` is the final in-scope v2 sub-issue for public product/plans/sign-in surfaces, Creem Storefront routing, and production external-integration acceptance.
 - `#13` is follow-on mobile-readiness/native strategy work outside `#5`.
 - `#16` is follow-on EDI sibling-product strategy work outside `#5`.
 
@@ -90,6 +95,7 @@ Additional v2 support issues:
 - `#26` adds Sentry-backed observability so hosted auth, billing, entitlement, webhook, and route-loader failures are visible without relying on console output.
 - `#27` adds development-only seeded users and browser auth states for exercising tiered access through production-like resolver paths.
 - `#28` removes URL-visible seed exposure from protected randomized practice by moving seed ownership into server-authoritative state.
+- `#36` turns the implemented v2 platform into a production-ready customer-facing product by adding clear plans/product pages, sign-in/account entry points, Pro Storefront CTAs, Enterprise inquiry-only messaging, paid-feature direction, and external integration acceptance tests.
 - `#13` and `#16` are separate strategy follow-ons and do not block `#5`.
 
 ## SEO And Knowledge-Surface Guardrails
@@ -112,13 +118,14 @@ Additional v2 support issues:
 | `I5D4` 20 lessons | `#9` | Editorial lessons remain authored, not AI-generated. |
 | `I5D5` 20 drill families | `#9` | Existing drills are regrouped into the family taxonomy. |
 | `I5D6` 20 scenario families | `#9` | Existing scenarios are absorbed into the family taxonomy. |
-| `I5D7` linked sub-issue execution plan | `#7`, `#11`, `#8`, `#9`, `#15`, `#21`, `#26`, `#27`, `#28` | Satisfied when the in-scope issue graph and plan set are in place. |
+| `I5D7` linked sub-issue execution plan | `#7`, `#11`, `#8`, `#9`, `#15`, `#21`, `#26`, `#27`, `#28`, `#36` | Satisfied when the in-scope issue graph and plan set are in place. |
 | `I5D8` separate higher-value randomization track | `#10` | Outline only in this phase. |
 | `I5D9` paid tiers, content gating, and premium access surfaces | `#21` | First paid-tier gating slice shipped in PR `#25`. |
-| `I5D10` deep wiki and directory reference expansion | `#15` | In-scope v2 knowledge-surface expansion remains open. |
-| `I5D11` hosted error observability | `#26` | Add Sentry Free-tier reporting with privacy-safe context. |
+| `I5D10` deep wiki and directory reference expansion | `#15` | Completed in PR `#34`, including carrier surfaces, directory metadata, structured data, sitemap coverage, and review follow-ups. |
+| `I5D11` hosted error observability | `#26` | Completed with privacy-safe Sentry Free-tier reporting through the shared observability wrapper. |
 | `I5D12` tiered dev auth fixtures | `#27` | Add seeded Free/Pro/Enterprise/canceled states and Playwright auth helpers. |
 | `I5D13` server-authoritative seed security | `#28` | Remove URL-visible seeds from protected randomized practice flows before certificate launch. |
+| `I5D14` final production readiness | `#36` | Add public plans/sign-in/storefront surfaces and complete the target-environment integration acceptance pass. |
 
 ## Rough Estimates
 
@@ -135,8 +142,9 @@ Additional v2 support issues:
 | `#26` | Sentry Free-tier observability | 4h | 2h |
 | `#27` | dev-only tiered seed users and Playwright auth states | 6h | 4h |
 | `#28` | seed-security hardening | 8h | 5h |
+| `#36` | final product, storefront, sign-in, and integration acceptance | 12h | 14h |
 | Core chain total | `#5` umbrella rollup (`#7/#11/#8/#9/#10`) | 100h | 52h |
-| Full `#5` web-v2 total | core chain plus `#12/#15/#21/#26/#27/#28` | 158h | 83h |
+| Full `#5` web-v2 total | core chain plus `#12/#15/#21/#26/#27/#28/#36` | 170h | 97h |
 | Separate strategy follow-ons | `#13` mobile-readiness and `#16` EDI sibling-product strategy | 14h | 6h |
 
 ## Dependencies
@@ -174,6 +182,7 @@ Additional v2 support issues:
 | Hosted failures remain console-only | production entitlement or billing failures are missed | Complete `#26` before enabling paid hosted rollout. |
 | Paid-tier QA depends on ad hoc accounts | regressions slip across Free/Pro/Enterprise/canceled states | Complete `#27` before relying on browser validation for paid access. |
 | URL-visible seeds remain in protected flows | copied URLs can reproduce randomized attempts and undermine future certificate validity | Complete `#28` before certificates or challenge-validity claims launch. |
+| Public product and checkout surfaces remain hidden in settings | Creem payment activation may be rejected and customers cannot understand or buy Pro | Complete `#36` with a public plans page, visible sign-in/account entry, Pro Storefront CTAs, Enterprise inquiry-only copy, and deployed integration acceptance. |
 
 ## Shared Product Boundaries
 
@@ -189,8 +198,8 @@ Additional v2 support issues:
 - durable progress and account history
 - entitlement-aware content access
 - premium variant banks and review modes
-- certificates and shareable credential pages
-- team and enterprise reporting
+- certificates and shareable credential pages remain future work until implemented
+- team and enterprise reporting remain future work and are not part of the current Pro Storefront launch
 
 ### Sibling-product surface
 
@@ -222,8 +231,11 @@ Every implementation issue in this chain must include iterative validation, not 
 This planning package is complete when:
 
 - the v2 issue plans and follow-on outline artifacts exist in `specs/current-changes`
-- GitHub issues `#5`, `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, `#27`, and `#28` match this structure
+- GitHub issues `#5`, `#7`, `#11`, `#8`, `#9`, `#10`, `#12`, `#15`, `#21`, `#26`, `#27`, `#28`, and `#36` match this structure
 - `#13` and `#16` are explicitly marked as separate strategy follow-ons outside `#5`
 - the memory-bank reflects the new order and scope
 - the repo is ready to execute work in branch order without inventing architecture mid-stream
 - the SEO, licensing, privacy, mobile-readiness, wiki-expansion, and sibling-product guardrails are explicit enough that later issues do not accidentally undermine them
+
+`#5` is ready to close only after `#36` is implemented and the production
+acceptance results are recorded.

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,8 +1,44 @@
 entries:
   - date: "2026-04-27"
+    version: "1.4.1.6"
+    commit: 94d76c2
+    status: committed
+    title: "docs(v2): add final production-readiness issue and align launch state"
+    details: |-
+      Created final v2 production-readiness issue `#36` under the `#5`
+      umbrella and aligned the local planning state around the remaining
+      launch gap.
+
+      What changed:
+
+      - Added
+        `specs/current-changes/issue-5-final-production-readiness-plan.md`
+        covering the public product/plans page, visible sign-in/account
+        entry points, Creem Storefront CTAs for the two Pro products,
+        Enterprise inquiry-only messaging, paid-feature navigation, and
+        external integration acceptance tests.
+      - Updated `specs/current-changes/issue-5-joint-plan.md` so `#36`
+        is the only remaining in-scope `#5` blocker.
+      - Updated `specs/memory-bank/active-context.yaml` to mark `#15`
+        and `#26` complete and leave `I5D14` as the remaining
+        deliverable.
+      - Updated `README.md` so implemented v2 infrastructure is no longer
+        described as planned and so Pro/Enterprise product state is clear.
+
+      Validation:
+
+      - `pnpm format`: passed after restoring unrelated formatter touches.
+      - Documentation consistency grep for stale v2/planned markers:
+        passed.
+    refs:
+      - "I5D14"
+      - "#5"
+      - "#36"
+
+  - date: "2026-04-27"
     version: "1.4.1.5"
-    commit: tbd
-    status: pending
+    commit: 105af7b
+    status: committed
     title: "chore(security): resolve remaining automated dependency and CodeQL alerts"
     details: |-
       Followed up on the remaining automated security and quality alerts

--- a/specs/memory-bank/CHANGELOG.yaml
+++ b/specs/memory-bank/CHANGELOG.yaml
@@ -1,7 +1,7 @@
 entries:
   - date: "2026-04-27"
     version: "1.4.1.6"
-    commit: 94d76c2
+    commit: 21e6f1f
     status: committed
     title: "docs(v2): add final production-readiness issue and align launch state"
     details: |-

--- a/specs/memory-bank/active-context.yaml
+++ b/specs/memory-bank/active-context.yaml
@@ -1,5 +1,5 @@
 meta:
-  release: "1.4.1.5"
+  release: "1.4.1.6"
   repo: "github.com/BallLightningAB/shipping-api-dojo"
   github-project: "https://github.com/users/BallLightningAB/projects/10"
   pdd_version: "1.0"
@@ -13,7 +13,7 @@ roadmap:
     - id: content-expansion
       issue: "#5"
       title: "Web v2 program: content expansion, hosted access, and knowledge surfaces"
-      status: in-progress
+      status: final-readiness
       priority: high
       links:
         issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/5"
@@ -31,9 +31,10 @@ roadmap:
         - "[I5D11] Add privacy-safe Sentry Free-tier observability for hosted v2 error paths"
         - "[I5D12] Add dev-only tiered auth users, billing-shaped seed state, and Playwright auth helpers"
         - "[I5D13] Remove URL-visible seeds from protected randomized practice flows before certificate launch"
+        - "[I5D14] Add public plans/sign-in/storefront surfaces and complete production integration acceptance testing"
       est:
-        dev_h: 158
-        test_h: 83
+        dev_h: 170
+        test_h: 97
       sub_issues:
         - id: content-expansion-scoping
           issue: "#7"
@@ -95,7 +96,7 @@ roadmap:
         - id: deep-wiki-expansion
           issue: "#15"
           title: "Deep wiki expansion by vendor, business unit, region, and protocol surface"
-          status: in-progress
+          status: done
           links:
             issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/15"
           progress_log:
@@ -110,7 +111,7 @@ roadmap:
         - id: sentry-observability
           issue: "#26"
           title: "Add Sentry Free-tier observability for hosted v2 errors"
-          status: planned
+          status: done
           links:
             issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/26"
         - id: dev-tier-seeded-users
@@ -126,9 +127,15 @@ roadmap:
           priority: critical
           links:
             issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/28"
+        - id: final-production-readiness
+          issue: "#36"
+          title: "Final v2 production readiness: public plans, Creem storefront, sign-in, and integration acceptance"
+          status: planned
+          priority: high
+          links:
+            issue: "https://github.com/BallLightningAB/shipping-api-dojo/issues/36"
       remaining_deliverables:
-        - "[I5D10] Expand the wiki and directory beyond curriculum support into the v2 carrier reference surface"
-        - "[I5D11] Add privacy-safe Sentry Free-tier observability for hosted v2 error paths"
+        - "[I5D14] Add public plans/sign-in/storefront surfaces and complete production integration acceptance testing"
       progress_log:
         - note: "Research captured in specs/current-changes/issue-5-content-expansion-research.md and GitHub issue #5 was updated to target minimum viable randomization, 20 lessons, 20 drill families, and 20 scenario families."
         - note: "Created the issue-5 joint plan plus issue-specific plan artifacts for #7, #11, #8, #9, and #10; added GitHub issue #11 for auth/billing/email/domain foundation; and updated the roadmap to sequence work as #7 -> #11 -> #8 -> #9 with #10 as follow-on."
@@ -203,6 +210,8 @@ roadmap:
           note: "Addressed the third Gemini review pass on PR #34 for issue #15 (commit 9acfbfb): hoisted the static groupSurfacesByVendor(carrierSurfaces) call out of CarrierIndexPage and into a module-scope carrierVendorGroups constant so the transformation runs once at module load; extracted a shared breadcrumbScripts(crumbs) helper in src/lib/seo/structured-data.ts that returns the head.scripts entry array (empty when generateBreadcrumbListSchema yields null) and updated all four wiki routes (/wiki, /wiki/$slug, /wiki/carriers, /wiki/carriers/$slug) to spread the helper so the conditional null-handling is centralized and cannot drift across routes; routed findRelatedConceptTitles in /wiki/carriers/$slug.tsx through the existing getWikiBySlug helper and dropped the now-unused wikiEntries import. Replied to all three PR #34 review threads. Validated with pnpm format, pnpm lint, pnpm typecheck, pre-commit, and pnpm test --run (151/151). Bumped meta.release to 1.4.1.3."
         - covers: [I5D10]
           note: "Addressed the fourth Gemini review pass on PR #34 for issue #15 (commit 401a676): hoisted the carrierVendorCount derivation (a Set over carrierSurfaces.map(... vendorSlug)) out of WikiIndexPage and into a module-scope constant in src/routes/wiki/index.tsx, matching the pattern already applied to carrierVendorGroups in /wiki/carriers/index.tsx so both static-data transformations run once at module load instead of on every render. Replied to the PR #34 review thread. Validated with pnpm format, pnpm lint, pnpm typecheck, pre-commit, and pnpm test --run (151/151). Bumped meta.release to 1.4.1.4."
+        - covers: [I5D14]
+          note: "Created final v2 production-readiness sub-issue #36 after the #5 completion audit found the remaining launch gap: public plans/sign-in surfaces, Creem Storefront CTAs for the two Pro product IDs, explicit Enterprise inquiry-only messaging, paid-feature navigation from product surfaces, and a targeted external integration acceptance pass. Marked #15 and #26 complete in the roadmap state and left #36 as the only remaining #5 deliverable before closing the umbrella."
   next_steps:
     - id: higher-value-randomization
       issue: "#10"


### PR DESCRIPTION
## Summary\n- create final #5 production-readiness plan for #36\n- align README, active-context, changelog, and the #5 joint plan around the remaining public plans/sign-in/Creem Storefront launch gap\n- keep #5 open only for #36 and clarify Pro-only storefront plus Enterprise inquiry-only state\n\n## Validation\n- pre-commit\n- pnpm format\n- pnpm lint\n- pnpm run typecheck\n\nRefs v1.4.1.6 #5 #36 I5D14-I5D14